### PR TITLE
Convert type description into struct type

### DIFF
--- a/src/main/java/com/github/sadikovi/riff/TypeDescription.java
+++ b/src/main/java/com/github/sadikovi/riff/TypeDescription.java
@@ -209,6 +209,20 @@ public class TypeDescription implements Serializable {
   }
 
   /**
+   * Convert this type description into Spark SQL struct type.
+   * @return struct type
+   */
+  public StructType toStructType() {
+    // StructField instances are immutable, therefore it is safe to pass them directly to
+    // construct struct type
+    StructType struct = new StructType();
+    for (int i = 0; i < ordinalFields.length; i++) {
+      struct = struct.add(ordinalFields[i].field());
+    }
+    return struct;
+  }
+
+  /**
    * Write type description into external output stream.
    * Does not close stream.
    * @param out output stream

--- a/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
+++ b/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
@@ -306,4 +306,28 @@ class TypeDescriptionSuite extends UnitTestSuite {
     td2.equals(td1) should be (true)
     td2.toString should be (td1.toString)
   }
+
+  test("convert to struct type") {
+    val schema = StructType(
+      StructField("col1", IntegerType) ::
+      StructField("col2", LongType) ::
+      StructField("col3", IntegerType) ::
+      StructField("col4", StringType) ::
+      StructField("col5", StringType) :: Nil)
+    val td = new TypeDescription(schema, Array("col4", "col1", "col5"))
+    td.toStructType() should be (StructType(
+      StructField("col4", StringType) ::
+      StructField("col1", IntegerType) ::
+      StructField("col5", StringType) ::
+      StructField("col2", LongType) ::
+      StructField("col3", IntegerType) :: Nil))
+  }
+
+  test("convert to struct type without index fields") {
+    val schema = StructType(
+      StructField("col1", IntegerType) ::
+      StructField("col2", LongType) :: Nil)
+    val td = new TypeDescription(schema)
+    td.toStructType() should be (schema)
+  }
 }


### PR DESCRIPTION
This PR adds method to `TypeDescription` to convert into `org.apache.spark.sql.types.StructType` taking into account positions of index fields.

It also adds methods to read type description separately from overall header file, and cache type description for subsequent calls. PR makes `FileReader` class not reusable, so when reading file twice, another reader must be created - this applies to both `prepareRead` and `readTypeDescription` methods.