### PR TITLE
Column filters

### DIFF
--- a/src/main/java/com/github/sadikovi/riff/ColumnFilter.java
+++ b/src/main/java/com/github/sadikovi/riff/ColumnFilter.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.util.sketch.BloomFilter;
+
+import com.github.sadikovi.riff.io.OutputBuffer;
+
+/**
+ * [[ColumnFilter]] class is a set that can resolve predicates with higher selectivity than
+ * statistics and should be considered optional optimization.
+ */
+public abstract class ColumnFilter {
+  protected final byte id;
+
+  protected ColumnFilter(byte id) {
+    this.id = id;
+  }
+
+  /**
+   * Filter might contain value of this bound reference.
+   * If filter contains value or it is unknown - return `true`, in other cases return `false`.
+   * This is similar to bloom filters.
+   * @param value
+   * @return true if node passes filter or unknown, false if node does not pass filter.
+   */
+  public abstract boolean mightContain(int value);
+  public abstract boolean mightContain(long value);
+  public abstract boolean mightContain(UTF8String value);
+
+  /**
+   * Update column filter with value in internal row at ordinal
+   * @param row row to use for update
+   * @param ordinal position of the value
+   */
+  public abstract void update(InternalRow row, int ordinal);
+
+  /**
+   * Write state of this filter into output buffer.
+   * There is not need to write id, it will be written automatically by `writeExternal`.
+   * @param buffer output buffer
+   * @throws IOException
+   */
+  protected abstract void writeState(OutputBuffer buffer) throws IOException;
+
+  /**
+   * Read state for this filter.
+   * Method should update any internal state that filter has so far.
+   * @param buffer byte buffer
+   * @throws IOException
+   */
+  protected abstract void readState(ByteBuffer buffer) throws IOException;
+
+  /**
+   * Select filter based on its byte id. Throws exception if id is not valid.
+   * @param id filter id
+   * @return filter instance
+   */
+  protected static ColumnFilter select(byte id) {
+    switch (id) {
+      case NoopColumnFilter.ID:
+        return new NoopColumnFilter();
+      case BloomColumnFilter.ID:
+        return new BloomColumnFilter();
+      default:
+        throw new UnsupportedOperationException("Unknown id: " + id);
+    }
+  }
+
+  /**
+   * Return new noop column filter.
+   * @return noop filter
+   */
+  public static ColumnFilter noopFilter() {
+    return new NoopColumnFilter();
+  }
+
+  /**
+   * Select typed bloom column filter.
+   * @param dataType Spark SQL data type
+   * @param numItems expected number of items
+   * @return bloom column filter
+   */
+  public static ColumnFilter sqlTypeToBloomFilter(DataType dataType, int numItems) {
+    if (dataType instanceof IntegerType) {
+      return new BloomColumnFilter(numItems) {
+        @Override
+        public void update(InternalRow row, int ordinal) {
+          filter.putLong(row.getInt(ordinal));
+        }
+      };
+    } else if (dataType instanceof LongType) {
+      return new BloomColumnFilter(numItems) {
+        @Override
+        public void update(InternalRow row, int ordinal) {
+          filter.putLong(row.getLong(ordinal));
+        }
+      };
+    } else if (dataType instanceof StringType) {
+      return new BloomColumnFilter(numItems) {
+        @Override
+        public void update(InternalRow row, int ordinal) {
+          filter.putBinary(row.getUTF8String(ordinal).getBytes());
+        }
+      };
+    } else {
+      throw new UnsupportedOperationException("Type for bloom column filter: " + dataType);
+    }
+  }
+
+  /**
+   * Deserialize filter from byte buffer.
+   * @param buffer byte buffer with filter data
+   * @return filter
+   * @throws IOException
+   */
+  public static ColumnFilter readExternal(ByteBuffer buffer) throws IOException {
+    ColumnFilter filter = select(buffer.get());
+    filter.readState(buffer);
+    return filter;
+  }
+
+  /**
+   * Write this filter into output buffer.
+   * @param output buffer
+   * @throws IOException
+   */
+  public final void writeExternal(OutputBuffer buffer) throws IOException {
+    buffer.writeByte(id);
+    writeState(buffer);
+  }
+
+  /**
+   * [[NoopColumnFilter]] represents null filter for fields that do not support filters.
+   * Instead of storing null in a filter array, we use noop filter. It always evaluates to `true`.
+   */
+  static class NoopColumnFilter extends ColumnFilter {
+    public static final byte ID = 1;
+
+    NoopColumnFilter() {
+      super(ID);
+    }
+
+    @Override
+    public void update(InternalRow row, int ordinal) {
+      // NoopColumnFilter does not update internal state
+    }
+
+    @Override
+    public boolean mightContain(int value) {
+      return true;
+    }
+
+    @Override
+    public boolean mightContain(long value) {
+      return true;
+    }
+
+    @Override
+    public boolean mightContain(UTF8String value) {
+      return true;
+    }
+
+    @Override
+    protected void writeState(OutputBuffer buffer) throws IOException {
+      // NoopColumnFilter does not have any state, no bytes are written input output.
+    }
+
+    @Override
+    protected void readState(ByteBuffer buffer) throws IOException {
+      // NoopColumnFilter does not have any state, no bytes are read from buffer.
+    }
+  }
+
+  /**
+   * [[BloomColumnFilter]] is backed by `BloomFilter` implementation in Spark sketch module.
+   * Since it can take a fair amount of bytes to serialize, should be used for index fields only.
+   * Each subclass must overwrite method to update filter for a given data type.
+   */
+  static class BloomColumnFilter extends ColumnFilter {
+    public static final byte ID = 125;
+    // default false positive probability
+    private static final double DEFAULT_FPP = 0.5;
+    // default number of records
+    private static final long DEFAULT_EXPECTED_ITEMS = 16;
+    // maximum number of items in filter
+    private static final long MAX_EXPECTED_ITEMS = 100000;
+
+    protected BloomFilter filter;
+
+    BloomColumnFilter() {
+      this(DEFAULT_EXPECTED_ITEMS, DEFAULT_FPP);
+    }
+
+    BloomColumnFilter(long numItems) {
+      this(numItems, DEFAULT_FPP);
+    }
+
+    BloomColumnFilter(long numItems, double fpp) {
+      super(ID);
+      this.filter = BloomFilter.create(Math.min(numItems, MAX_EXPECTED_ITEMS), fpp);
+    }
+
+    @Override
+    public void update(InternalRow row, int ordinal) {
+      throw new RuntimeException("Column filter is in read-only state");
+    }
+
+    @Override
+    public boolean mightContain(int value) {
+      return filter.mightContainLong(value);
+    }
+
+    @Override
+    public boolean mightContain(long value) {
+      return filter.mightContainLong(value);
+    }
+
+    @Override
+    public boolean mightContain(UTF8String value) {
+      return filter.mightContainBinary(value.getBytes());
+    }
+
+    @Override
+    protected void writeState(OutputBuffer buffer) throws IOException {
+      // we have to create separate buffer to write bytes so we can read from byte buffer
+      OutputBuffer tmp = new OutputBuffer();
+      filter.writeTo(tmp);
+      buffer.writeInt(tmp.bytesWritten());
+      buffer.writeBytes(tmp.array());
+    }
+
+    @Override
+    protected void readState(ByteBuffer buffer) throws IOException {
+      int len = buffer.getInt();
+      ByteArrayInputStream in = new ByteArrayInputStream(buffer.array(),
+        buffer.arrayOffset() + buffer.position(), len);
+      filter = BloomFilter.readFrom(in);
+      buffer.position(buffer.position() + len);
+    }
+  }
+}

--- a/src/main/java/com/github/sadikovi/riff/FileReader.java
+++ b/src/main/java/com/github/sadikovi/riff/FileReader.java
@@ -243,6 +243,14 @@ public class FileReader {
             keep = state.tree().evaluate(stripes[i].getStatistics());
           }
         }
+        // if predicate passes statistics, evaluate column filters
+        if (keep && stripes[i].hasColumnFilters()) {
+          if (state.hasIndexedTreeOnly()) {
+            keep = state.indexTree().evaluate(stripes[i].getColumnFilters());
+          } else {
+            keep = state.tree().evaluate(stripes[i].getColumnFilters());
+          }
+        }
 
         if (!keep) {
           stripes[i] = null;

--- a/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -399,6 +399,7 @@ public class FileWriter {
     Statistics[] stats = new Statistics[td.fields().length];
     for (int i = 0; i < td.fields().length; i++) {
       stats[i] = Statistics.sqlTypeToStatistics(td.fields()[i].dataType());
+      LOG.info("Create statistics {} for field {}", stats[i], td.fields()[i]);
     }
     return stats;
   }
@@ -431,7 +432,8 @@ public class FileWriter {
     ColumnFilter[] filters = new ColumnFilter[td.fields().length];
     for (int i = 0; i < td.fields().length; i++) {
       if (td.fields()[i].isIndexed()) {
-        filters[i] = ColumnFilter.sqlTypeToBloomFilter(td.fields()[i].dataType(), stripeRows);
+        filters[i] = ColumnFilter.sqlTypeToColumnFilter(td.fields()[i].dataType(), stripeRows);
+        LOG.info("Create filter {} for indexed field {}", filters[i], td.fields()[i]);
       } else {
         filters[i] = ColumnFilter.noopFilter();
       }

--- a/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -426,9 +426,9 @@ public class FileWriter {
    */
   private static ColumnFilter[] createColumnFilters(
       TypeDescription td, boolean enabled, int stripeRows) {
-    if (!enabled) return null;
+    // column filters are created only if enabled and type description contains any indexed fields
+    if (!enabled || td.indexFields().length == 0) return null;
     ColumnFilter[] filters = new ColumnFilter[td.fields().length];
-    // column filters are created for index fields only
     for (int i = 0; i < td.fields().length; i++) {
       if (td.fields()[i].isIndexed()) {
         filters[i] = ColumnFilter.sqlTypeToBloomFilter(td.fields()[i].dataType(), stripeRows);

--- a/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -83,6 +83,8 @@ public class FileWriter {
   private final int bufferSize;
   // HDFS buffer size for creating stream
   private final int hdfsBufferSize;
+  // whether or not column filters are enabled
+  private final boolean columnFilterEnabled;
   // compression codec, can be null
   private final CompressionCodec codec;
 
@@ -106,6 +108,8 @@ public class FileWriter {
   private int stripeCurrentRecords;
   // statistics per stripe
   private Statistics[] stripeStats;
+  // column filters per stripe
+  private ColumnFilter[] stripeFilters;
 
   /**
    * Create file writer for path.
@@ -147,7 +151,11 @@ public class FileWriter {
     this.numRowsInStripe = Riff.Options.numRowsInStripe(conf);
     this.bufferSize = Riff.Options.power2BufferSize(conf);
     this.hdfsBufferSize = Riff.Options.hdfsBufferSize(conf);
+    this.columnFilterEnabled = Riff.Options.columnFilterEnabled(conf);
     this.codec = codec;
+    // current stripe stats and filters
+    this.stripeStats = null;
+    this.stripeFilters = null;
   }
 
   /**
@@ -248,6 +256,7 @@ public class FileWriter {
     stripe = new StripeOutputBuffer(stripeId++);
     stripeStream = new OutStream(bufferSize, codec, stripe);
     stripeStats = createStatistics(td);
+    stripeFilters = createColumnFilters(td, columnFilterEnabled, numRowsInStripe);
     stripeCurrentRecords = numRowsInStripe;
     LOG.info("Initialize stripe outstream {}", stripeStream);
     // create stream for data file
@@ -276,9 +285,9 @@ public class FileWriter {
       if (stripeCurrentRecords == 0) {
         // flush data into stripe buffer
         stripeStream.flush();
-        // write stripe information into output, such as
-        // stripe id and length, and capture position
-        StripeInformation stripeInfo = new StripeInformation(stripe, out.getPos(), stripeStats);
+        // write stripe information into output, such as stripe id and length, and capture position
+        StripeInformation stripeInfo =
+          new StripeInformation(stripe, out.getPos(), stripeStats, stripeFilters);
         stripe.flush(out);
         LOG.info("Finished writing stripe {}, records={}", stripeInfo, numRowsInStripe);
         stripes.add(stripeInfo);
@@ -288,6 +297,7 @@ public class FileWriter {
         stripeStats = createStatistics(td);
       }
       updateStatistics(stripeStats, td, row);
+      updateColumnFilters(stripeFilters, td, row);
       recordWriter.writeRow(row, stripeStream);
       stripeCurrentRecords--;
     } catch (IOException ioe) {
@@ -406,6 +416,43 @@ public class FileWriter {
     }
   }
 
+  /**
+   * Create new array of column filters for a stripe.
+   * Returns null if column filters are disabled.
+   * @param td type description
+   * @param enabled true if column filters are enabled
+   * @param stripeRows expected number of rows in stripe
+   * @return array of column filters or null if filters are disabled
+   */
+  private static ColumnFilter[] createColumnFilters(
+      TypeDescription td, boolean enabled, int stripeRows) {
+    if (!enabled) return null;
+    ColumnFilter[] filters = new ColumnFilter[td.fields().length];
+    // column filters are created for index fields only
+    for (int i = 0; i < td.fields().length; i++) {
+      if (td.fields()[i].isIndexed()) {
+        filters[i] = ColumnFilter.sqlTypeToBloomFilter(td.fields()[i].dataType(), stripeRows);
+      } else {
+        filters[i] = ColumnFilter.noopFilter();
+      }
+    }
+    return filters;
+  }
+
+  /**
+   * Update each instance of column filters with value of internal row.
+   * @param filters array of filters, can be null
+   * @param td type description
+   * @param row row to use for updates
+   */
+  private static void updateColumnFilters(
+      ColumnFilter[] filters, TypeDescription td, InternalRow row) {
+    if (filters == null) return;
+    for (int i = 0; i < filters.length; i++) {
+      filters[i].update(row, td.atPosition(i).origSQLPos());
+    }
+  }
+
   @Override
   public String toString() {
     return "FileWriter[" +
@@ -415,6 +462,7 @@ public class FileWriter {
       ", rows_per_stripe=" + numRowsInStripe +
       ", is_compressed=" + (codec != null) +
       ", buffer_size=" + bufferSize +
-      ", hdfs_buffer_size=" + hdfsBufferSize + "]";
+      ", hdfs_buffer_size=" + hdfsBufferSize +
+      ", column_filter_enabled=" + columnFilterEnabled + "]";
   }
 }

--- a/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -94,6 +94,11 @@ public class Riff {
     // default buffer size for HDFS, should be multiple of 4096 bytes, same as in core-default.xml
     public static final int HDFS_BUFFER_SIZE_DEFAULT = 4 * 1024;
 
+    // whether or not column filters are enabled and should be written into header
+    public static final String COLUMN_FILTER_ENABLED = "riff.column.filter.enabled";
+    // column filters are enabled by default
+    public static final boolean COLUMN_FILTER_ENABLED_DEFAULT = false;
+
     /**
      * Select next power of 2 as buffer size.
      * @param conf configuration
@@ -101,12 +106,12 @@ public class Riff {
      */
     static int power2BufferSize(Configuration conf) {
       int bytes = conf.getInt(BUFFER_SIZE, BUFFER_SIZE_DEFAULT);
-      if (bytes > Riff.Options.BUFFER_SIZE_MAX) return Riff.Options.BUFFER_SIZE_MAX;
-      if (bytes < Riff.Options.BUFFER_SIZE_MIN) return Riff.Options.BUFFER_SIZE_MIN;
+      if (bytes > BUFFER_SIZE_MAX) return BUFFER_SIZE_MAX;
+      if (bytes < BUFFER_SIZE_MIN) return BUFFER_SIZE_MIN;
       // bytes is already power of 2
       if ((bytes & (bytes - 1)) == 0) return bytes;
       bytes = Integer.highestOneBit(bytes) << 1;
-      return (bytes < Riff.Options.BUFFER_SIZE_MAX) ? bytes : Riff.Options.BUFFER_SIZE_MAX;
+      return (bytes < BUFFER_SIZE_MAX) ? bytes : BUFFER_SIZE_MAX;
     }
 
     /**
@@ -129,13 +134,22 @@ public class Riff {
      * @return number of rows in stripe, or throws exception if number is invalid
      */
     static int numRowsInStripe(Configuration conf) {
-      int rows = conf.getInt(Riff.Options.STRIPE_ROWS, Riff.Options.STRIPE_ROWS_DEFAULT);
+      int rows = conf.getInt(STRIPE_ROWS, STRIPE_ROWS_DEFAULT);
       // there should be positive number of rows in stripe
       if (rows < 1) {
         throw new IllegalArgumentException("Expected positive number of rows in stripe, found " +
           rows + " <= 0");
       }
       return rows;
+    }
+
+    /**
+     * Select column filters (enable/disable).
+     * @param conf configuration
+     * @return true if column filters are enabled
+     */
+    static boolean columnFilterEnabled(Configuration conf) {
+      return conf.getBoolean(COLUMN_FILTER_ENABLED, COLUMN_FILTER_ENABLED_DEFAULT);
     }
   }
 

--- a/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -300,6 +300,17 @@ public class Riff {
     }
 
     /**
+     * Enable or disable column filters when writing file.
+     * They are used by reader automatically if available.
+     * @param enable true to write filters, false otherwise
+     * @return this instance
+     */
+    public WriterBuilder enableColumnFilter(boolean enable) {
+      this.conf.setBoolean(Options.COLUMN_FILTER_ENABLED, enable);
+      return this;
+    }
+
+    /**
      * Set type description for writer.
      * @param td type description to use, must not be null
      * @return this instance

--- a/src/main/java/com/github/sadikovi/riff/tree/BoundReference.java
+++ b/src/main/java/com/github/sadikovi/riff/tree/BoundReference.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 
 /**
@@ -250,7 +251,7 @@ public abstract class BoundReference implements TreeNode {
 
   //////////////////////////////////////////////////////////////
   // Statistics support
-  // Overwrite any of the methods below if filter can be evaluated based on statistics
+  // Overwrite any of the methods below if node can be evaluated based on statistics
   //////////////////////////////////////////////////////////////
 
   @Override
@@ -304,6 +305,27 @@ public abstract class BoundReference implements TreeNode {
    * @return true if predicate passes statistics, false otherwise
    */
   public boolean statUpdate(UTF8String min, UTF8String max) {
+    return true;
+  }
+
+  //////////////////////////////////////////////////////////////
+  // Column filter support
+  // Overwrite any of the methods below if node can be evaluated based on column filters
+  //////////////////////////////////////////////////////////////
+
+  @Override
+  public boolean evaluate(ColumnFilter[] filters) {
+    // method assumes that tree is resolved to access ordinal
+    return evaluateFilter(filters[ordinal]);
+  }
+
+  /**
+   * Evaluate column filter for this bound reference.
+   * This should invoke `mightContain` method of filter if this node supports filtering.
+   * @param filter for this node
+   * @return true if node value passes filter or unknown, false if value does not pass filter
+   */
+  protected boolean evaluateFilter(ColumnFilter filter) {
     return true;
   }
 }

--- a/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
+++ b/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.tree.Tree.And;
 import com.github.sadikovi.riff.tree.Tree.GreaterThan;
 import com.github.sadikovi.riff.tree.Tree.GreaterThanOrEqual;
@@ -230,6 +231,10 @@ public class FilterApi {
       @Override public boolean statUpdate(int min, int max) {
         return min <= value && value <= max;
       }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        return filter.mightContain(value);
+      }
     };
   }
 
@@ -253,6 +258,10 @@ public class FilterApi {
 
       @Override public boolean statUpdate(long min, long max) {
         return min <= value && value <= max;
+      }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        return filter.mightContain(value);
       }
     };
   }
@@ -278,6 +287,10 @@ public class FilterApi {
       @Override public boolean statUpdate(UTF8String min, UTF8String max) {
         if (min == null && max == null) return false;
         return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
+      }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        return filter.mightContain(value);
       }
     };
   }
@@ -623,6 +636,13 @@ public class FilterApi {
         }
         return false;
       }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        for (int i = 0; i < arr.length; i++) {
+          if (filter.mightContain(arr[i])) return true;
+        }
+        return false;
+      }
     };
   }
 
@@ -652,6 +672,13 @@ public class FilterApi {
       @Override public boolean statUpdate(long min, long max) {
         for (int i = 0; i < arr.length; i++) {
           if (arr[i] >= min && arr[i] <= max) return true;
+        }
+        return false;
+      }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        for (int i = 0; i < arr.length; i++) {
+          if (filter.mightContain(arr[i])) return true;
         }
         return false;
       }
@@ -685,6 +712,13 @@ public class FilterApi {
         if (min == null && max == null) return false;
         for (int i = 0; i < arr.length; i++) {
           if (arr[i].compareTo(min) >= 0 && arr[i].compareTo(max) <= 0) return true;
+        }
+        return false;
+      }
+
+      @Override protected boolean evaluateFilter(ColumnFilter filter) {
+        for (int i = 0; i < arr.length; i++) {
+          if (filter.mightContain(arr[i])) return true;
         }
         return false;
       }

--- a/src/main/java/com/github/sadikovi/riff/tree/Tree.java
+++ b/src/main/java/com/github/sadikovi/riff/tree/Tree.java
@@ -30,6 +30,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.NullType;
 import org.apache.spark.unsafe.types.UTF8String;
 
+import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 
 public class Tree {
@@ -260,6 +261,11 @@ public class Tree {
     }
 
     @Override
+    public boolean evaluate(ColumnFilter[] filters) {
+      return left.evaluate(filters) && right.evaluate(filters);
+    }
+
+    @Override
     public TreeNode transform(Rule rule) {
       return rule.update(this);
     }
@@ -304,6 +310,11 @@ public class Tree {
     }
 
     @Override
+    public boolean evaluate(ColumnFilter[] filters) {
+      return left.evaluate(filters) || right.evaluate(filters);
+    }
+
+    @Override
     public TreeNode transform(Rule rule) {
       return rule.update(this);
     }
@@ -316,6 +327,7 @@ public class Tree {
 
   /**
    * "Not" unary logical node, negates expression of child.
+   * TODO: fix how not handles state, currently `not` would inverse "unknown" state.
    */
   public static class Not extends UnaryLogicalNode {
     private final TreeNode child;
@@ -337,6 +349,11 @@ public class Tree {
     @Override
     public boolean evaluate(Statistics[] stats) {
       return !child.evaluate(stats);
+    }
+
+    @Override
+    public boolean evaluate(ColumnFilter[] filters) {
+      return !child.evaluate(filters);
     }
 
     @Override
@@ -375,6 +392,11 @@ public class Tree {
 
     @Override
     public boolean evaluate(Statistics[] stats) {
+      return result;
+    }
+
+    @Override
+    public boolean evaluate(ColumnFilter[] filters) {
       return result;
     }
 

--- a/src/main/java/com/github/sadikovi/riff/tree/TreeNode.java
+++ b/src/main/java/com/github/sadikovi/riff/tree/TreeNode.java
@@ -24,6 +24,7 @@ package com.github.sadikovi.riff.tree;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 
+import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 
 /**
@@ -57,6 +58,15 @@ public interface TreeNode {
    * @return true if predicate is unknown or evaluated, false if it does not pass statistics
    */
   boolean evaluate(Statistics[] stats);
+
+  /**
+   * Evaluate tree for provided non-null array of column filters. They are loaded as part of stripe
+   * information, and each ordinal of filter instance corresponds to the ordinal of type spec - and
+   * matches ordinal stored for each leaf node. Each filter is guaranteed to be non-null.
+   * @param filters array of column filters
+   * @return true if predicate is unknown or evaluated, false if it does not pass filter
+   */
+  boolean evaluate(ColumnFilter[] filters);
 
   /**
    * Transform current tree based on rule. This should always return a copy of tree with

--- a/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
+++ b/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff
+
+import java.io.IOException
+import java.nio.ByteBuffer
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
+
+import com.github.sadikovi.riff.io.OutputBuffer
+import com.github.sadikovi.testutil.UnitTestSuite
+
+class ColumnFilterSuite extends UnitTestSuite {
+  test("noop filter returns true for all contains methods") {
+    val filter = ColumnFilter.noopFilter()
+    filter.mightContain(1) should be (true)
+    filter.mightContain(1L) should be (true)
+    filter.mightContain(UTF8String.fromString("1")) should be (true)
+  }
+
+  test("noop filter does not write state except id") {
+    val filter = ColumnFilter.noopFilter()
+    val out = new OutputBuffer()
+    filter.writeExternal(out)
+    out.array should be (Array[Byte](1))
+  }
+
+  test("noop filter write/read") {
+    val filter1 = ColumnFilter.noopFilter()
+    val out = new OutputBuffer()
+    filter1.writeExternal(out)
+
+    val filter2 = ColumnFilter.readExternal(ByteBuffer.wrap(out.array));
+    filter2 should be (filter1)
+  }
+
+  test("select bloom filter for different types") {
+    val row = InternalRow(1, 2L, UTF8String.fromString("3"))
+    val filter1 = ColumnFilter.sqlTypeToColumnFilter(IntegerType, 64)
+    filter1.mightContain(row.getInt(0)) should be (false)
+    filter1.update(row, 0)
+    filter1.mightContain(row.getInt(0)) should be (true)
+
+    val filter2 = ColumnFilter.sqlTypeToColumnFilter(LongType, 64)
+    filter2.mightContain(row.getLong(1)) should be (false)
+    filter2.update(row, 1)
+    filter2.mightContain(row.getLong(1)) should be (true)
+
+    val filter3 = ColumnFilter.sqlTypeToColumnFilter(StringType, 64)
+    filter3.mightContain(row.getUTF8String(2)) should be (false)
+    filter3.update(row, 2)
+    filter3.mightContain(row.getUTF8String(2)) should be (true)
+  }
+
+  test("bloom filter write/read") {
+    val row = InternalRow(1, 2L, UTF8String.fromString("3"))
+    val out = new OutputBuffer()
+    val filter1 = ColumnFilter.sqlTypeToColumnFilter(IntegerType, 64)
+    filter1.update(row, 0)
+    filter1.writeExternal(out)
+    val filter2 = ColumnFilter.readExternal(ByteBuffer.wrap(out.array))
+    filter2 should be (filter1)
+    filter2.mightContain(row.getInt(0)) should be (true)
+  }
+
+  test("select noop filter for unsupported data type") {
+    val filter = ColumnFilter.sqlTypeToColumnFilter(NullType, 10)
+    filter should be (ColumnFilter.noopFilter)
+  }
+
+  test("fail to read column filter with invalid id") {
+    val err = intercept[IOException] {
+      ColumnFilter.readExternal(ByteBuffer.wrap(Array[Byte](Byte.MinValue)))
+    }
+    err.getMessage should be (s"Unknown column filter id: ${Byte.MinValue}")
+  }
+}

--- a/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
+++ b/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
@@ -197,7 +197,7 @@ class FileReaderSuite extends UnitTestSuite {
     // stripe 0 should be discarded because of column filter
     res should be (Array(stripes(1)))
   }
-  
+
   test("file reader reuse") {
     withTempDir { dir =>
       val writer = Riff.writer.setTypeDesc(td).create(dir / "path")

--- a/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
+++ b/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
@@ -57,7 +57,8 @@ class FileWriterSuite extends UnitTestSuite {
         s"rows_per_stripe=${Riff.Options.STRIPE_ROWS_DEFAULT}, " +
         s"is_compressed=${codec != null}, " +
         s"buffer_size=${Riff.Options.BUFFER_SIZE_DEFAULT}, " +
-        s"hdfs_buffer_size=${Riff.Options.HDFS_BUFFER_SIZE_DEFAULT}]")
+        s"hdfs_buffer_size=${Riff.Options.HDFS_BUFFER_SIZE_DEFAULT}, " +
+        s"column_filter_enabled=${Riff.Options.COLUMN_FILTER_ENABLED_DEFAULT}]")
     }
   }
 
@@ -80,7 +81,8 @@ class FileWriterSuite extends UnitTestSuite {
         s"rows_per_stripe=${Riff.Options.STRIPE_ROWS_DEFAULT}, " +
         s"is_compressed=${codec != null}, " +
         s"buffer_size=${Riff.Options.BUFFER_SIZE_DEFAULT}, " +
-        s"hdfs_buffer_size=${Riff.Options.HDFS_BUFFER_SIZE_DEFAULT}]")
+        s"hdfs_buffer_size=${Riff.Options.HDFS_BUFFER_SIZE_DEFAULT}, " +
+        s"column_filter_enabled=${Riff.Options.COLUMN_FILTER_ENABLED_DEFAULT}]")
     }
   }
 

--- a/src/test/scala/com/github/sadikovi/riff/StripeInformationSuite.scala
+++ b/src/test/scala/com/github/sadikovi/riff/StripeInformationSuite.scala
@@ -45,11 +45,15 @@ class StripeInformationSuite extends UnitTestSuite {
 
   test("toString method") {
     val info1 = new StripeInformation(123.toByte, 12345L, Int.MaxValue, null)
-    info1.toString should be (
-      s"Stripe[id=123, offset=12345, length=${Int.MaxValue}, has_stats=false]")
+    info1.toString should be (s"Stripe[id=123, offset=12345, length=${Int.MaxValue}, " +
+      "has_stats=false, has_column_filters=false]")
     val info2 = new StripeInformation(123.toByte, 12345L, Int.MaxValue, Array[Statistics]())
-    info2.toString should be (
-      s"Stripe[id=123, offset=12345, length=${Int.MaxValue}, has_stats=true]")
+    info2.toString should be (s"Stripe[id=123, offset=12345, length=${Int.MaxValue}, " +
+      "has_stats=true, has_column_filters=false]")
+    val info3 = new StripeInformation(123.toByte, 12345L, Int.MaxValue, Array[Statistics](),
+      Array[ColumnFilter]())
+    info3.toString should be (s"Stripe[id=123, offset=12345, length=${Int.MaxValue}, " +
+      "has_stats=true, has_column_filters=true]")
   }
 
   test("assert negative values in stripe information") {
@@ -144,7 +148,7 @@ class StripeInformationSuite extends UnitTestSuite {
     stripe2 = new StripeInformation(1.toByte, 123L, 101, null)
     assert(stripe1 != stripe2)
 
-    stripe1 = new StripeInformation(1.toByte, 123L, 100, Array.empty)
+    stripe1 = new StripeInformation(1.toByte, 123L, 100, Array.empty[Statistics])
     stripe2 = new StripeInformation(1.toByte, 123L, 100, null)
     assert(stripe1 != stripe2)
 


### PR DESCRIPTION
This PR adds option to include column filters for index columns (if any). Column filter is essentially wrapper for `BloomFilter` in Spark, but this abstraction allows to maintain filters for columns that do not support it directly.

Right now, column filters are disabled by default and can be configured using boolean option `riff.column.filter.enabled` in hadoop configuration.

TODO:
- [x] Add tests (including tests for file writer and reader, riff suite tests, stripe tests)
- [x] Add logging for column filters (on write/read and creation)

Fixes #14.