### PR TITLE
Spark SQL file format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,9 @@ unmanagedSourceDirectories in Test += baseDirectory.value / "common" / "src" / "
 // format and specification project
 unmanagedSourceDirectories in Compile += baseDirectory.value / "format" / "src" / "main"
 unmanagedSourceDirectories in Test += baseDirectory.value / "format" / "src" / "test"
+// sql project
+unmanagedSourceDirectories in Compile += baseDirectory.value / "sql" / "src" / "main"
+unmanagedSourceDirectories in Test += baseDirectory.value / "sql" / "src" / "test"
 
 // tasks dependencies
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")

--- a/format/src/main/java/com/github/sadikovi/riff/FileReader.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileReader.java
@@ -121,9 +121,9 @@ public class FileReader {
       LOG.info("Read header flags {}", Arrays.toString(flags));
       CompressionCodec codec = Riff.decodeCompressionCodec(flags[0]);
       if (codec == null) {
-        LOG.info("Found no compression codec");
+        LOG.debug("Found no compression codec, using uncompressed");
       } else {
-        LOG.info("Found compression codec {}", codec);
+        LOG.debug("Found compression codec {}", codec);
       }
       // initialize valid predicate state if necessary
       PredicateState state = null;
@@ -147,7 +147,7 @@ public class FileReader {
       Statistics[] fileStats = new Statistics[buffer.getInt()];
       for (int i = 0; i < fileStats.length; i++) {
         fileStats[i] = Statistics.readExternal(buffer);
-        LOG.info("Read file statistics {}", fileStats[i]);
+        LOG.debug("Read file statistics {}", fileStats[i]);
       }
       // if predicate state is available - evaluate tree and decide on whether or not to read the
       // file any further.
@@ -166,7 +166,7 @@ public class FileReader {
       }
       // read stripe information until no bytes are available in buffer
       final int contentLen = in.readInt();
-      LOG.info("Read content of {} bytes", contentLen);
+      LOG.debug("Read content of {} bytes", contentLen);
       buffer = ByteBuffer.allocate(contentLen);
       // do not flip buffer after this operation as we write directly into underlying array
       in.readFully(buffer.array(), buffer.arrayOffset(), buffer.limit());

--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -251,18 +251,18 @@ public class FileWriter {
     stripeId = 0;
     stripes = new ArrayList<StripeInformation>();
     recordWriter = new IndexedRowWriter(td);
-    LOG.info("Initialized record writer {}", recordWriter);
+    LOG.debug("Initialized record writer {}", recordWriter);
     // initialize stripe related parameters
     stripe = new StripeOutputBuffer(stripeId++);
     stripeStream = new OutStream(bufferSize, codec, stripe);
     stripeStats = createStatistics(td);
     stripeFilters = createColumnFilters(td, columnFilterEnabled, numRowsInStripe);
     stripeCurrentRecords = numRowsInStripe;
-    LOG.info("Initialize stripe outstream {}", stripeStream);
+    LOG.debug("Initialize stripe outstream {}", stripeStream);
     // create stream for data file
     try {
       out = fs.create(dataPath, false, hdfsBufferSize);
-      LOG.info("Prepare data file header");
+      LOG.debug("Prepare data file header");
       writeHeader(out);
     } catch (IOException ioe) {
       if (out != null) {
@@ -289,7 +289,7 @@ public class FileWriter {
         StripeInformation stripeInfo =
           new StripeInformation(stripe, out.getPos(), stripeStats, stripeFilters);
         stripe.flush(out);
-        LOG.info("Finished writing stripe {}, records={}", stripeInfo, numRowsInStripe);
+        LOG.debug("Finished writing stripe {}, records={}", stripeInfo, numRowsInStripe);
         stripes.add(stripeInfo);
         stripe = new StripeOutputBuffer(stripeId++);
         stripeStream = new OutStream(bufferSize, codec, stripe);
@@ -321,7 +321,7 @@ public class FileWriter {
       stripeStream.flush();
       StripeInformation stripeInfo = new StripeInformation(stripe, out.getPos(), stripeStats);
       stripe.flush(out);
-      LOG.info("Finished writing stripe {}, records={}", stripeInfo,
+      LOG.debug("Finished writing stripe {}, records={}", stripeInfo,
         numRowsInStripe - stripeCurrentRecords);
       stripes.add(stripeInfo);
       stripeStream.close();
@@ -333,7 +333,7 @@ public class FileWriter {
       LOG.info("Finished writing data file {}", dataPath);
 
       // write header file
-      LOG.info("Prepare header file");
+      LOG.debug("Prepare header file");
       out = fs.create(headerPath, false, hdfsBufferSize);
       writeHeader(out);
       writeHeaderState(out);
@@ -341,7 +341,7 @@ public class FileWriter {
       td.writeTo(out);
       // == file content ==
       // combine all statistics for a file
-      LOG.info("Merge stripe statistics");
+      LOG.debug("Merge stripe statistics");
       Statistics[] fileStats = createStatistics(td);
       for (StripeInformation info : stripes) {
         if (info.hasStatistics()) {
@@ -350,7 +350,7 @@ public class FileWriter {
           }
         }
       }
-      LOG.info("Write header file content");
+      LOG.debug("Write header file content");
       // buffer stores content of the entire header file content, when being read, this should be
       // loaded into byte buffer
       OutputBuffer buffer = new OutputBuffer();

--- a/format/src/main/java/com/github/sadikovi/riff/GenericInternalRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/GenericInternalRow.java
@@ -48,7 +48,7 @@ public abstract class GenericInternalRow extends InternalRow {
     throw new UnsupportedOperationException();
   }
 
-  public final void update(int ordinal, Object value) {
+  public void update(int ordinal, Object value) {
     throw new UnsupportedOperationException();
   }
 

--- a/format/src/main/java/com/github/sadikovi/riff/PredicateState.java
+++ b/format/src/main/java/com/github/sadikovi/riff/PredicateState.java
@@ -203,7 +203,13 @@ public class PredicateState {
 
     @Override
     public Tree update(Not node) {
-      return new Not(node.child().transform(this));
+      // there is an issue when Not results in inversing correct trivial node, e.g.
+      // Not(IsNull("col")), where "col" is a data field, meaning that IsNull("col") is replaced to
+      // TRUE, and Not inverses result, meaning that 0 records will be returned.
+      // In this case we should check on returned node
+      Tree updated = node.child().transform(this);
+      if (updated instanceof Trivial) return updated;
+      return new Not(updated);
     }
 
     @Override

--- a/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff;
+
+import java.util.Arrays;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.NullType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * [[ProjectionRow]] is a simple mutable row backed by array of objects with support for updates.
+ * Needs to be in sync with supported types of [[IndexedRow]].
+ */
+public class ProjectionRow extends GenericInternalRow {
+  // internal array to keep all values
+  private final Object[] values;
+
+  /**
+   * Create instance of this row with expected number of fields.
+   * @param size number of fields
+   */
+  public ProjectionRow(int size) {
+    this.values = new Object[size];
+  }
+
+  /**
+   * Create instance of this row with provided array.
+   * Array reference is held by row, no copy is done.
+   * @param values array of values
+   */
+  protected ProjectionRow(Object[] values) {
+    this.values = values;
+  }
+
+  /**
+   * Get underlying array of values. Used internally to compare and for testing.
+   * @return array of values
+   */
+  protected Object[] values() {
+    return values;
+  }
+
+  @Override
+  public int numFields() {
+    return values.length;
+  }
+
+  @Override
+  public void update(int ordinal, Object value) {
+    values[ordinal] = value;
+  }
+
+  @Override
+  public ProjectionRow copy() {
+    Object[] copy = new Object[values.length];
+    System.arraycopy(values, 0, copy, 0, values.length);
+    return new ProjectionRow(copy);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || !(other instanceof ProjectionRow)) return false;
+    if (other == this) return true;
+    ProjectionRow row = (ProjectionRow) other;
+    return row.numFields() == this.numFields() && Arrays.equals(row.values(), this.values());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 31 * numFields();
+    result += Arrays.hashCode(values);
+    return result;
+  }
+
+  @Override
+  public boolean anyNull() {
+    int len = values.length, i = 0;
+    while (i < len) {
+      if (isNullAt(i)) return true;
+      ++i;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isNullAt(int ordinal) {
+    return values[ordinal] == null;
+  }
+
+  /** Method to cast and retrieve integer value */
+  private Integer getIntegerValue(int ordinal) {
+    return (Integer) values[ordinal];
+  }
+
+  @Override
+  public int getInt(int ordinal) {
+    return getIntegerValue(ordinal).intValue();
+  }
+
+  /** Method to cast and retrieve long value */
+  private Long getLongValue(int ordinal) {
+    return (Long) values[ordinal];
+  }
+
+  @Override
+  public long getLong(int ordinal) {
+    return getLongValue(ordinal).longValue();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int ordinal) {
+    return (UTF8String) values[ordinal];
+  }
+
+  @Override
+  public Object get(int ordinal, DataType dataType) {
+    if (isNullAt(ordinal) || dataType instanceof NullType) {
+      return null;
+    } else if (dataType instanceof IntegerType) {
+      return getIntegerValue(ordinal);
+    } else if (dataType instanceof LongType) {
+      return getLongValue(ordinal);
+    } else if (dataType instanceof StringType) {
+      return getUTF8String(ordinal);
+    } else {
+      throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
+    }
+  }
+
+  @Override
+  public String toString() {
+    if (values.length == 0) {
+      return "[empty row]";
+    } else {
+      return Arrays.toString(values);
+    }
+  }
+}

--- a/format/src/main/java/com/github/sadikovi/riff/tree/Tree.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/Tree.java
@@ -22,6 +22,8 @@
 
 package com.github.sadikovi.riff.tree;
 
+import java.io.Serializable;
+
 import org.apache.spark.sql.catalyst.InternalRow;
 
 import com.github.sadikovi.riff.ColumnFilter;
@@ -34,7 +36,7 @@ import com.github.sadikovi.riff.TypeDescription;
  * considered immutable when transforming. State is evaluated for internal row, considered always
  * resolved and returns `true` when internal row passes predicate or `false` otherwise.
  */
-public interface Tree {
+public interface Tree extends Serializable {
   /**
    * Evaluate state for this tree.
    * @param row row to evaluate

--- a/format/src/main/java/com/github/sadikovi/riff/tree/TypedExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/TypedExpression.java
@@ -22,6 +22,8 @@
 
 package com.github.sadikovi.riff.tree;
 
+import java.io.Serializable;
+
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
 
@@ -33,7 +35,7 @@ import com.github.sadikovi.riff.ColumnFilter;
  * All predicate related methods should be implement following this rule:
  * {value at ordinal <action> this expression}.
  */
-public interface TypedExpression<E> extends Comparable<E> {
+public interface TypedExpression<E> extends Comparable<E>, Serializable {
   /**
    * Associated Spark SQL data type for this expression.
    * @return data type

--- a/format/src/test/scala/com/github/sadikovi/riff/IndexedRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/IndexedRowSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.github.sadikovi.riff.io._
-import com.github.sadikovi.riff.tree.Tree
+import com.github.sadikovi.riff.tree.{FilterApi, Tree}
 import com.github.sadikovi.riff.tree.FilterApi._
 import com.github.sadikovi.testutil.UnitTestSuite
 
@@ -416,6 +416,21 @@ class IndexedRowSuite extends UnitTestSuite {
     ind(1).getInt(td.position("col1")) should be (2)
     ind(2).getUTF8String(td.position("col2")) should be (UTF8String.fromString("abc"))
     ind(2).getInt(td.position("col1")) should be (3)
+    ind(3) should be (null)
+    ind(4) should be (null)
+  }
+
+  test("write/read with predicate Not(IsNull)") {
+    val (td, ind) = readWithPredicate(
+      and(
+        FilterApi.not(nvl("col1")),
+        eqt("col1", 1)
+      )
+    )
+    assert(ind(0) != null)
+    ind(0).getInt(td.position("col1")) should be (1)
+    ind(1) should be (null)
+    ind(2) should be (null)
     ind(3) should be (null)
     ind(4) should be (null)
   }

--- a/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff
+
+import org.apache.spark.unsafe.types.UTF8String
+
+import com.github.sadikovi.testutil.UnitTestSuite
+
+class ProjectionRowSuite extends UnitTestSuite {
+  test("initialize with array of values") {
+    val values = Array(1, 2, 3).map(_.asInstanceOf[AnyRef])
+    val row = new ProjectionRow(values)
+    row.numFields should be (3)
+    row.anyNull should be (false)
+    row.toString should be ("[1, 2, 3]")
+  }
+
+  test("initialize row with size") {
+    val row = new ProjectionRow(3)
+    row.numFields should be (3)
+    row.anyNull should be (true)
+    row.toString should be ("[null, null, null]")
+  }
+
+  test("initialize empty row") {
+    val row = new ProjectionRow(0)
+    row.numFields should be (0)
+    row.anyNull should be (false)
+    row.toString should be ("[empty row]")
+  }
+
+  test("update values") {
+    val row = new ProjectionRow(3)
+    row.numFields should be (3)
+    row.anyNull should be (true)
+    row.toString should be ("[null, null, null]")
+
+    row.update(0, 1)
+    row.update(1, 2)
+    row.update(2, 3)
+    row.anyNull should be (false)
+    row.toString should be ("[1, 2, 3]")
+  }
+
+  test("get values") {
+    val row = new ProjectionRow(3)
+    row.update(0, 1)
+    row.update(1, 2L)
+    row.update(2, UTF8String.fromString("abc"))
+
+    row.getInt(0) should be (1)
+    row.getLong(1) should be (2L)
+    row.getUTF8String(2) should be (UTF8String.fromString("abc"))
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/io/InStreamSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/io/InStreamSuite.scala
@@ -228,4 +228,19 @@ class InStreamSuite extends UnitTestSuite {
       in.reset()
     }
   }
+
+  test("compressed, instream is refilled during readInt()") {
+    // this test exposes issue when the same buffer was reused for reading header and would
+    // overwrite previously written bytes
+    val source = new StripeInputBuffer(1.toByte, Array[Byte](
+      /* header */
+      0, 0, 0, 3,
+      0, 0, 0,
+      -128, 0, 0, 13,
+      /* bytes: 12, 0, 0, 0, 125, 0, 0, 0, 0, 0, 0, 0, 125, 2, 3, 4 */
+      -29, 97, 96, 96, -88, 101, -128, -128, 90, 38, 102, 22, 0
+    ))
+    val in = new InStream(16, new ZlibCodec(), source)
+    in.readInt() should be (12)
+  }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
@@ -537,4 +537,20 @@ class FilterSuite extends UnitTestSuite {
     tree.evaluateState(Array(filter("aa"), filter(1))) should be (false)
     tree.evaluateState(Array(filter("v1"), filter(2))) should be (false)
   }
+
+  test("FilterApi - evaluate tree with Not(IsNull) predicate for row") {
+    val schema = StructType(
+      StructField("col1", IntegerType) ::
+      StructField("col2", StringType) ::
+      StructField("col3", LongType) :: Nil)
+    val td = new TypeDescription(schema, Array("col2"))
+    val tree = and(
+      FilterApi.not(nvl("col1")),
+      eqt("col1", 1)
+    )
+
+    tree.analyze(td)
+    tree.evaluateState(InternalRow(UTF8String.fromString("abc1"), 1, 1L)) should be (true)
+    tree.evaluateState(InternalRow(UTF8String.fromString("abc2"), 1, 2L)) should be (true)
+  }
 }

--- a/sql/src/main/java/com/github/sadikovi/riff/hadoop/RiffOutputCommitter.java
+++ b/sql/src/main/java/com/github/sadikovi/riff/hadoop/RiffOutputCommitter.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.hadoop;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.sadikovi.riff.Metadata;
+import com.github.sadikovi.riff.Riff;
+
+/**
+ * Riff output committer.
+ * Provides methods to save metadata for the output folder.
+ *
+ * Note: Spark SQL does not use custom output committer when appending data to the existing table,
+ * in our case it is okay, since we store only static information that does not change with writing
+ * more data. In the future, if it is required to update metadata files, we will need to provide
+ * custom commit protocol as subclass of `HadoopMapReduceCommitProtocol` through option
+ * "spark.sql.sources.commitProtocolClass".
+ */
+public class RiffOutputCommitter extends FileOutputCommitter {
+  private static final Logger LOG = LoggerFactory.getLogger(RiffOutputCommitter.class);
+
+  // root directory for write
+  private final Path outputPath;
+
+  public RiffOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+    super(outputPath, context);
+    this.outputPath = outputPath;
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    LOG.info("Commit job for path {}", outputPath);
+    super.commitJob(jobContext);
+    writeMetadataFile(jobContext.getConfiguration(), outputPath);
+  }
+
+  /**
+   * Write Riff metadata file.
+   * @param conf hadoop configuration
+   * @param outputPath root path for output
+   * @throws IOException
+   */
+  private static void writeMetadataFile(Configuration conf, Path outputPath) throws IOException {
+    // Right now, merging of the schema is not supported as we do not support schema evolution or
+    // merge. At this point, just find the first file of riff format and write metadata for it.
+    FileSystem fs = outputPath.getFileSystem(conf);
+    FileStatus status = fs.getFileStatus(outputPath);
+    List<FileStatus> partFiles = listFiles(fs, status, true);
+    if (partFiles.isEmpty()) {
+      LOG.warn("Could not find any part files for path {}, metadata is ignored", outputPath);
+    } else {
+      Metadata.MetadataWriter writer = Riff.metadataWriter().setFileSystem(fs).setConf(conf)
+        .create(partFiles.get(0).getPath());
+      writer.writeMetadataFile(outputPath);
+      LOG.info("Finished writing metadata file for {}", outputPath);
+    }
+  }
+
+  /**
+   * Filter to read only part files, and discard any files that start with "_" or ".".
+   */
+  static class PartFileFilter implements PathFilter {
+    public static final PartFileFilter instance = new PartFileFilter();
+
+    private PartFileFilter() {}
+
+    @Override
+    public boolean accept(Path path) {
+      return !path.getName().startsWith("_") && !path.getName().startsWith(".");
+    }
+  }
+
+  /**
+   * List all part files recursively, or return the first file found.
+   * @param fs file system
+   * @param fileStatus current directory file status or file
+   * @param fetchOneFile whether or not to return just first found file or traverse fully
+   * @return list of file statuses for part files
+   */
+  static List<FileStatus> listFiles(
+      FileSystem fs,
+      FileStatus fileStatus,
+      boolean fetchOneFile) throws IOException {
+    List<FileStatus> files = new ArrayList<FileStatus>();
+    recurListFiles(fs, fileStatus, files, fetchOneFile);
+    return files;
+  }
+
+  private static void recurListFiles(
+      FileSystem fs,
+      FileStatus fileStatus,
+      List<FileStatus> foundFiles,
+      boolean fetchOneFile) throws IOException {
+    if (fetchOneFile && !foundFiles.isEmpty()) return;
+    if (fileStatus.isDirectory()) {
+      FileStatus[] list = fs.listStatus(fileStatus.getPath(), PartFileFilter.instance);
+      for (int i = 0; i < list.length; i++) {
+        recurListFiles(fs, list[i], foundFiles, fetchOneFile);
+      }
+    } else {
+      // file status is a file, add to the list
+      foundFiles.add(fileStatus);
+    }
+  }
+}

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -180,10 +180,11 @@ class DefaultSource
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
     // right now Spark appends partition values to each row, would be good to do it internally
-    // TODO: handle partition values append internally
+    // TODO: handle partition values append internally, similar to ParquetFileFormat
     val projectionFields = requiredSchema.fieldNames.distinct.toArray
-    require(projectionFields.nonEmpty,
-      s"Found empty list of projection fields for schema $requiredSchema")
+    // if projection fields are empty, count is requested, empty projection is generated, but we
+    // read all fields.
+    // TODO: store count in metadata and return dummy iterator of that many rows
 
     // check if filter pushdown disabled
     val filterPushdownEnabled = sparkSession.conf.get(SQL_RIFF_FILTER_PUSHDOWN,

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.spark.riff
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.mapreduce.{Job, TaskAttemptContext}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.riff.{RiffOutputWriter, RiffOutputWriterFactory}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources._
+import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
+import org.apache.spark.sql.types.StructType
+
+import org.slf4j.LoggerFactory
+
+import com.github.sadikovi.riff.Riff.Options
+import com.github.sadikovi.riff.TypeDescription
+import com.github.sadikovi.riff.io.CompressionCodecFactory
+import com.github.sadikovi.riff.hadoop.RiffOutputCommitter
+
+/**
+ * Spark SQL datasource for Riff file format.
+ */
+class DefaultSource
+  extends FileFormat
+  with DataSourceRegister
+  with Serializable {
+
+  import RiffFileFormat._
+
+  // logger for file format, since we cannot use internal Spark logging
+  @transient private val log = LoggerFactory.getLogger(classOf[DefaultSource])
+
+  override def shortName(): String = "riff"
+
+  override def toString(): String = "Riff"
+
+  override def hashCode(): Int = getClass.hashCode()
+
+  override def equals(obj: Any): Boolean = obj.isInstanceOf[DefaultSource]
+
+  override def prepareWrite(
+      sparkSession: SparkSession,
+      job: Job,
+      options: Map[String, String],
+      dataSchema: StructType): OutputWriterFactory = {
+    // create type description and try extracting index fields if any
+    // if index fields are not set, pass empty array value
+    val indexFields: Array[String] = options.get(INDEX_FIELDS_OPTION) match {
+      case Some(value) => parseIndexFields(value)
+      case None => Array.empty
+    }
+    log.info(s"Found optional index fields as ${indexFields.mkString("[", ", ", "]")}")
+    val typeDesc = new TypeDescription(dataSchema, indexFields)
+    log.info(s"Using type description $typeDesc to write output")
+
+    // set job configuration based on provided Spark options, if not set - noop
+    val conf = job.getConfiguration()
+    // set compression codec, riff does not have default compression codec value, therefore
+    // we just select one ourselves
+    conf.set(Options.COMPRESSION_CODEC,
+      sparkSession.conf.get(SQL_RIFF_COMPRESSION_CODEC, SQL_RIFF_COMPRESSION_CODEC_DEFAULT))
+
+    // set stripe size
+    conf.set(Options.STRIPE_ROWS,
+      sparkSession.conf.get(SQL_RIFF_STRIPE_ROWS, s"${Options.STRIPE_ROWS_DEFAULT}"))
+
+    // set column filters
+    conf.set(Options.COLUMN_FILTER_ENABLED,
+      sparkSession.conf.get(SQL_RIFF_COLUMN_FILTER_ENABLED,
+        s"${Options.COLUMN_FILTER_ENABLED_DEFAULT}"))
+
+    // set buffer size for outstream in riff
+    conf.set(Options.BUFFER_SIZE,
+      sparkSession.conf.get(SQL_RIFF_BUFFER_SIZE, s"${Options.BUFFER_SIZE_DEFAULT}"))
+
+    val committerClass = classOf[RiffOutputCommitter]
+    log.info(s"Using output committer for Riff: ${committerClass.getCanonicalName}")
+    conf.setClass(SPARK_OUTPUT_COMMITTER_CLASS, committerClass, classOf[RiffOutputCommitter])
+
+    new RiffOutputWriterFactory(typeDesc)
+  }
+
+  override def inferSchema(
+      sparkSession: SparkSession,
+      parameters: Map[String, String],
+      files: Seq[FileStatus]): Option[StructType] = {
+    None
+  }
+
+  override def isSplitable(
+      sparkSession: SparkSession,
+      options: Map[String, String],
+      path: Path): Boolean = {
+    // TODO: update file format to support split
+    false
+  }
+
+  override def buildReaderWithPartitionValues(
+      sparkSession: SparkSession,
+      dataSchema: StructType,
+      partitionSchema: StructType,
+      requiredSchema: StructType,
+      filters: Seq[Filter],
+      options: Map[String, String],
+      hadoopConf: Configuration): (PartitionedFile) => Iterator[InternalRow] = {
+    null
+  }
+}
+
+object RiffFileFormat {
+  // datasource option for fields to index; must be provided as comma-separated list of values
+  val INDEX_FIELDS_OPTION = "index"
+
+  // compression codec to use when writing riff files
+  val SQL_RIFF_COMPRESSION_CODEC = "spark.sql.riff.compression.codec"
+  // default codec for this file format
+  val SQL_RIFF_COMPRESSION_CODEC_DEFAULT = "deflate"
+  // number of rows per stripe to write
+  val SQL_RIFF_STRIPE_ROWS = "spark.sql.riff.stripe.rows"
+  // enable column filters for index fields
+  val SQL_RIFF_COLUMN_FILTER_ENABLED = "spark.sql.riff.column.filter.enabled"
+  // set buffer size in bytes for outstream
+  val SQL_RIFF_BUFFER_SIZE = "spark.sql.riff.buffer.size"
+
+  // internal Spark SQL option for output committer
+  val SPARK_OUTPUT_COMMITTER_CLASS = "spark.sql.sources.outputCommitterClass"
+
+  /**
+   * Parse index fields string into list of indexed columns.
+   * @param fields comma-separated list of field names that exist in data schema
+   * @return array of index fields
+   */
+  def parseIndexFields(fields: String): Array[String] = {
+    if (fields == null || fields.length == 0) {
+      Array.empty
+    } else {
+      // remove empty field names
+      fields.split(',').map(_.trim).filter(_.nonEmpty)
+    }
+  }
+}

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
 
 import com.github.sadikovi.riff.{Buffers, Riff}
+import com.github.sadikovi.riff.ProjectionRow
 import com.github.sadikovi.riff.Riff.Options
 import com.github.sadikovi.riff.TypeDescription
 import com.github.sadikovi.riff.io.CompressionCodecFactory
@@ -234,7 +235,7 @@ class DefaultSource
 
             override def next: InternalRow = {
               val row = iter.next()
-              val proj = new GenericInternalRow(new Array[Any](projectionFields.length))
+              val proj = new ProjectionRow(projectionFields.length)
               var i = 0
               while (i < projectionFields.length) {
                 val spec = td.atPosition(td.position(projectionFields(i)))

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
@@ -71,6 +71,10 @@ private[riff] object Filters {
       case IsNotNull(attribute: String) =>
         not(nvl(attribute))
       case And(left: Filter, right: Filter) =>
+        // TODO: Remove Not(IsNull) tree node when there exists an equality for that column
+        // e.g. (!(col1[0] is null)) && (col1[0] > 100). This is how Spark pushes down predicate to
+        // source and adds filters that we do not need to evaluate since our filters are already
+        // null safe.
         and(recurBuild(left), recurBuild(right))
       case Or(left: Filter, right: Filter) =>
         or(recurBuild(left), recurBuild(right))

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.spark.riff
+
+import org.apache.spark.sql.sources._
+
+import com.github.sadikovi.riff.tree.Tree
+import com.github.sadikovi.riff.tree.FilterApi._
+
+/**
+ * Utility functions to convert Spark SQL filters into Riff filters.
+ */
+private[riff] object Filters {
+  /**
+   * Create new Riff filter for SQL filter.
+   * @param filter optional filter
+   * @return predicate tree or null if filter is None
+   */
+  def createRiffFilter(filter: Option[Filter]): Tree = {
+    if (filter.isDefined) {
+      recurBuild(filter.get)
+    } else {
+      null
+    }
+  }
+
+  /**
+   * Recursively build tree.
+   * Tree is not analyzed at this point.
+   */
+  private def recurBuild(filter: Filter): Tree = {
+    filter match {
+      case EqualTo(attribute: String, value: Any) =>
+        eqt(attribute, value)
+      case EqualNullSafe(attribute: String, value: Any) =>
+        // for us we treat `EqualNullSafe` as  `EqualTo` or `IsNull` depending on value
+        if (value == null) nvl(attribute) else eqt(attribute, value)
+      case GreaterThan(attribute: String, value: Any) =>
+        gt(attribute, value)
+      case GreaterThanOrEqual(attribute: String, value: Any) =>
+        ge(attribute, value)
+      case LessThan(attribute: String, value: Any) =>
+        lt(attribute, value)
+      case LessThanOrEqual(attribute: String, value: Any) =>
+        le(attribute, value)
+      case In(attribute: String, values: Array[Any]) =>
+        // scala does not like passing Any into vargs
+        in(attribute, values.map(_.asInstanceOf[AnyRef]))
+      case IsNull(attribute: String) =>
+        nvl(attribute)
+      case IsNotNull(attribute: String) =>
+        not(nvl(attribute))
+      case And(left: Filter, right: Filter) =>
+        and(recurBuild(left), recurBuild(right))
+      case Or(left: Filter, right: Filter) =>
+        or(recurBuild(left), recurBuild(right))
+      case Not(child: Filter) =>
+        not(recurBuild(child))
+      case other =>
+        // for unsupported predicates return `true`,
+        // relying on Spark to do additional filtering
+        // - StringStartsWith
+        // - StringEndsWith
+        // - StringContains
+        TRUE
+    }
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.apache.spark.sql.riff
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.TaskAttemptContext
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.BucketingUtils
+import org.apache.spark.sql.execution.datasources.{OutputWriter, OutputWriterFactory}
+import org.apache.spark.sql.types.StructType
+
+import com.github.sadikovi.riff.{Riff, TypeDescription}
+import com.github.sadikovi.riff.io.CompressionCodecFactory
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Riff output writer factory to create instances of output writer on each executor.
+ * To support both 2.0 and 2.1 versions of Spark we provide 2 methods of `newInstance` which are
+ * handled separately by output writer.
+ */
+class RiffOutputWriterFactory(val desc: TypeDescription) extends OutputWriterFactory {
+  override def getFileExtension(context: TaskAttemptContext): String = {
+    val conf = context.getConfiguration()
+    CompressionCodecFactory.fileExtForShortName(conf.get(Riff.Options.COMPRESSION_CODEC)) + ".riff"
+  }
+
+  /**
+   * Method for Spark 2.0.x, where it is required to provide bucket id.
+   * We do not use `override` modifier since this method is removed in 2.1
+   */
+  def newInstance(
+      path: String,
+      bucketId: Option[Int],
+      dataSchema: StructType,
+      context: TaskAttemptContext): OutputWriter = {
+    // legacy support for Spark 2.0.x
+    val legacySupport = true
+    new RiffOutputWriter(path, desc, context, getFileExtension(context), legacySupport, bucketId)
+  }
+
+  def newInstance(
+      path: String,
+      dataSchema: StructType,
+      context: TaskAttemptContext): OutputWriter = {
+    // bucket id has been removed in 2.1 and full path is sent to the writer
+    val legacySupport = false
+    new RiffOutputWriter(path, desc, context, getFileExtension(context), legacySupport)
+  }
+}
+
+/**
+ * Riff output writer for a single file, initialized on each executor.
+ */
+class RiffOutputWriter(
+    path: String,
+    typeDesc: TypeDescription,
+    context: TaskAttemptContext,
+    extension: String,
+    legacySupport: Boolean,
+    bucketId: Option[Int] = None)
+  extends OutputWriter {
+
+  @transient private val log = LoggerFactory.getLogger(classOf[RiffOutputWriter])
+
+  // create writer using hadoop configuration for task attempt
+  val configuration = context.getConfiguration()
+  val filepath = if (legacySupport) {
+    // we create file name manually taking into account bucket id (if provided)
+    val uniqueWriteJobId = configuration.get("spark.sql.sources.writeJobUUID")
+    val taskAttemptId = context.getTaskAttemptID
+    val split = taskAttemptId.getTaskID.getId
+    val bucketString = bucketId.map(BucketingUtils.bucketIdToString).getOrElse("")
+    new Path(path, f"part-r-$split%05d-$uniqueWriteJobId$bucketString.json$extension")
+  } else {
+    new Path(path)
+  }
+  // prepare riff writer, all options should be set through hadoop configuration
+  val writer = Riff.writer
+    .setTypeDesc(typeDesc)
+    .setConf(configuration)
+    .create(filepath)
+  log.info(s"Using file writer $writer")
+  writer.prepareWrite()
+
+  override def write(row: Row): Unit = {
+    // writer supports internal row writes only
+    throw new UnsupportedOperationException("call writeInternal")
+  }
+
+  // this method is protected[sql] in Spark
+  override def writeInternal(row: InternalRow): Unit = {
+    writer.write(row)
+  }
+
+  override def close(): Unit = {
+    writer.finishWrite()
+  }
+}

--- a/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory
  * handled separately by output writer.
  */
 class RiffOutputWriterFactory(val desc: TypeDescription) extends OutputWriterFactory {
-  override def getFileExtension(context: TaskAttemptContext): String = {
+  def getFileExtension(context: TaskAttemptContext): String = {
     val conf = context.getConfiguration()
     CompressionCodecFactory.fileExtForShortName(conf.get(Riff.Options.COMPRESSION_CODEC)) + ".riff"
   }

--- a/sql/src/main/scala/org/apache/spark/sql/riff/SerializableConfiguration.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/riff/SerializableConfiguration.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.apache.spark.sql.riff
+
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import org.apache.hadoop.conf.Configuration
+
+/**
+ * Serializable hadoop configuration. Clone of `org.apache.spark.util.SerializableConfiguration`,
+ * since it cannot be reused outside `spark` package.
+ */
+class SerializableConfiguration(@transient var value: Configuration) extends Serializable {
+  private def writeObject(out: ObjectOutputStream): Unit = {
+    out.defaultWriteObject()
+    value.write(out)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = {
+    value = new Configuration(false)
+    value.readFields(in)
+  }
+}


### PR DESCRIPTION
This PR adds SQL file format and fixes several bugs in Riff format.
There are some TODOs created that I will be addressing later, and will add tests for SQL in separate PR.

This PR also adds `ProjectionRow` to work around column pruning that is not supported by format.