### PR TITLE
Fix UTF8 statistics corrupt values

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/Statistics.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Statistics.java
@@ -360,10 +360,12 @@ public abstract class Statistics extends GenericInternalRow {
     /**
      * Return deep copy of UTF8String, this method forcefully copies `getBytes()` bytes in
      * UTF8String, since it does not return copy when backed by single array.
+     * Clone is null safe, and would return null for null input.
      * @param str UTF8 string to clone
      * @return copy
      */
     private UTF8String clone(UTF8String str) {
+      if (str == null) return null;
       byte[] bytes = new byte[str.numBytes()];
       System.arraycopy(str.getBytes(), 0, bytes, 0, bytes.length);
       return UTF8String.fromBytes(bytes);

--- a/format/src/main/java/com/github/sadikovi/riff/Statistics.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Statistics.java
@@ -357,11 +357,24 @@ public abstract class Statistics extends GenericInternalRow {
       super(ID);
     }
 
+    /**
+     * Return deep copy of UTF8String, this method forcefully copies `getBytes()` bytes in
+     * UTF8String, since it does not return copy when backed by single array.
+     * @param str UTF8 string to clone
+     * @return copy
+     */
+    private UTF8String clone(UTF8String str) {
+      byte[] bytes = new byte[str.numBytes()];
+      System.arraycopy(str.getBytes(), 0, bytes, 0, bytes.length);
+      return UTF8String.fromBytes(bytes);
+    }
+
     @Override
     protected void updateState(InternalRow row, int ordinal) {
       UTF8String value = row.getUTF8String(ordinal);
-      min = (min == null) ? value : (min.compareTo(value) > 0 ? value : min);
-      max = (max == null) ? value : (max.compareTo(value) < 0 ? value : max);
+      // only clone on actual update
+      min = (min == null) ? clone(value) : (min.compareTo(value) > 0 ? clone(value) : min);
+      max = (max == null) ? clone(value) : (max.compareTo(value) < 0 ? clone(value) : max);
     }
 
     @Override
@@ -405,15 +418,15 @@ public abstract class Statistics extends GenericInternalRow {
       UTF8StringStatistics that = (UTF8StringStatistics) obj;
       // update min
       if (this.min == null || that.min == null) {
-        this.min = this.min == null ? that.min : this.min;
+        this.min = this.min == null ? clone(that.min) : this.min;
       } else {
-        this.min = this.min.compareTo(that.min) > 0 ? that.min : this.min;
+        this.min = this.min.compareTo(that.min) > 0 ? clone(that.min) : this.min;
       }
       // update max
       if (this.max == null || that.max == null) {
-        this.max = this.max == null ? that.max : this.max;
+        this.max = this.max == null ? clone(that.max) : this.max;
       } else {
-        this.max = this.max.compareTo(that.max) < 0 ? that.max : this.max;
+        this.max = this.max.compareTo(that.max) < 0 ? clone(that.max) : this.max;
       }
       // update nulls
       this.hasNulls = this.hasNulls || that.hasNulls;

--- a/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
@@ -133,6 +133,24 @@ class StatisticsSuite extends UnitTestSuite {
     utfStats.getUTF8String(Statistics.ORD_MAX) should be (UTF8String.fromString("abc"))
   }
 
+  test("ensure copy when updating state for utf8 stats") {
+    val utfStats = Statistics.sqlTypeToStatistics(StringType)
+    val min = Array[Byte](97, 98, 99, 100)
+    val max = Array[Byte](100, 101, 102, 103)
+    utfStats.update(InternalRow(UTF8String.fromBytes(min)), 0)
+    utfStats.update(InternalRow(UTF8String.fromBytes(max)), 0)
+    // update min/max arrays
+    min(0) = 100
+    max(0) = 99
+    utfStats.update(InternalRow(UTF8String.fromBytes(min)), 0)
+    utfStats.update(InternalRow(UTF8String.fromBytes(max)), 0)
+
+    utfStats.getUTF8String(Statistics.ORD_MIN) should be (
+      UTF8String.fromBytes(Array[Byte](97, 98, 99, 100)))
+    utfStats.getUTF8String(Statistics.ORD_MAX) should be (
+      UTF8String.fromBytes(Array[Byte](100, 101, 102, 103)))
+  }
+
   test("write/read for empty int stats") {
     val buf = new OutputBuffer()
     val intStats = Statistics.sqlTypeToStatistics(IntegerType)

--- a/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
@@ -34,6 +34,17 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
     stopSparkSession
   }
 
+  test("parse index fields for option") {
+    RiffFileFormat.parseIndexFields(null) should be (Array.empty)
+    RiffFileFormat.parseIndexFields("") should be (Array.empty)
+    RiffFileFormat.parseIndexFields(",") should be (Array.empty)
+    RiffFileFormat.parseIndexFields(",,,") should be (Array.empty)
+    RiffFileFormat.parseIndexFields("col1,col2,col3") should be (Array("col1", "col2", "col3"))
+    RiffFileFormat.parseIndexFields("col1, col2, col3") should be (Array("col1", "col2", "col3"))
+    RiffFileFormat.parseIndexFields("   col1   ") should be (Array("col1"))
+    RiffFileFormat.parseIndexFields("col1, , col3") should be (Array("col1", "col3"))
+  }
+
   test("write/read riff non-partitioned table") {
     val implicits = spark.implicits
     withTempDir { dir =>


### PR DESCRIPTION
This PR addresses issue for UTF8 statistics where min value (and potentially max value) on stripe level and file level would store corrupt value. This was happening due to reuse of underlying byte array and thus overwriting previous values. Fixed by doing force copy whenever update is made.

Before:
```
UTF8[hasNulls=false, min=abc149990 abc149990 abc149990, max=abc999993 abc999993 abc999993]
UTF8[hasNulls=false, min=98abc49998 , max=abc999993 abc999993 abc999993]
UTF8[hasNulls=false, min=8 abc49998a, max=abc999993 abc999993 abc999993]
UTF8[hasNulls=false, min= abc49998 abc4999, max=abc999993 abc999993 abc999993]
```

After:
```
UTF8[hasNulls=false, min=abc100009 abc100009 abc100009, max=abc999992 abc999992 abc999992]
UTF8[hasNulls=false, min=abc100009 abc100009 abc100009, max=abc999992 abc999992 abc999992]
UTF8[hasNulls=false, min=abc100009 abc100009 abc100009, max=abc999992 abc999992 abc999992]
UTF8[hasNulls=false, min=abc100009 abc100009 abc100009, max=abc999992 abc999992 abc999992]
```