### PR TITLE
Clean up file format

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -46,9 +46,10 @@ import com.github.sadikovi.riff.io.OutStream;
 import com.github.sadikovi.riff.io.StripeOutputBuffer;
 
 /**
- * File writer provides methods to prepare files and write rows into data file. It creates two
- * files at the end of the operation: one is header file containing all metadata about stripes,
- * offsets and statistics in the stream and another is data file containing raw bytes of data.
+ * File writer provides methods to prepare files and write rows into riff data file. It creates two
+ * files at the end of the operation: temporary data file that is removed once all data has been
+ * copied into riff file, and actual riff file containing all metadata about stripes, offsets and
+ * statistics in the stream and raw bytes of data.
  * This class should be used per thread, is not thread-safe.
  *
  * Usage:
@@ -64,7 +65,7 @@ import com.github.sadikovi.riff.io.StripeOutputBuffer;
  * Writer should be used only to create file once, reuses are not allowed - create a new
  * instance instead. Multiple calls of `prepareWrite` are allowed and result in no-op, the same
  * goes for `finishWrite` method. When `finishWrite` is called, writer flushes the last stripe and
- * creates header file for the already written data file.
+ * creates riff file for the already written temporary data file.
  */
 public class FileWriter {
   private static final Logger LOG = LoggerFactory.getLogger(FileWriter.class);

--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -231,7 +231,7 @@ public class FileWriter {
   public void prepareWrite() throws IOException {
     if (writeFinished) throw new IOException("Writer reuse");
     if (writePrepared) return;
-    LOG.info("Prepare file's type description {}", td);
+    LOG.debug("Prepare file's type description {}", td);
     stripeId = 0;
     currentOffset = 0L;
     stripes = new ArrayList<StripeInformation>();

--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -72,7 +72,7 @@ public class Riff {
   private static final Logger LOG = LoggerFactory.getLogger(Riff.class);
 
   public static final String MAGIC = "RIFF";
-  // suffix for data files
+  // suffix for temporary data files
   public static final String DATA_FILE_SUFFIX = ".data";
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -167,12 +167,13 @@ public class Riff {
   }
 
   /**
-   * Append data file suffix to the path, suffix is always the last block in file name.
-   * @param path header path
-   * @return data path
+   * Construct path to the temporary data file.
+   * @param path file path
+   * @return temporary data path
    */
   static Path makeDataPath(Path path) {
-    return path.suffix(DATA_FILE_SUFFIX);
+    // prefix file name with "." and append suffix
+    return new Path(path.getParent(), new Path("." + path.getName() + DATA_FILE_SUFFIX));
   }
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -72,8 +72,6 @@ public class Riff {
   private static final Logger LOG = LoggerFactory.getLogger(Riff.class);
 
   public static final String MAGIC = "RIFF";
-  // suffix for temporary data files
-  public static final String DATA_FILE_SUFFIX = ".data";
 
   /**
    * Internal riff options that can be set in hadoop configuration.
@@ -172,8 +170,8 @@ public class Riff {
    * @return temporary data path
    */
   static Path makeDataPath(Path path) {
-    // prefix file name with "." and append suffix
-    return new Path(path.getParent(), new Path("." + path.getName() + DATA_FILE_SUFFIX));
+    // prefix file name with "." and append ".data" suffix
+    return new Path(path.getParent(), new Path("." + path.getName() + ".data"));
   }
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/io/FSAppendStream.java
+++ b/format/src/main/java/com/github/sadikovi/riff/io/FSAppendStream.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class FSAppendStream extends OutputStream {
+  // output stream as destination
+  private OutputStream out;
+  // temporary buffer that is used to copy bytes directly
+  private byte[] copyBuffer;
+
+  public FSAppendStream(OutputStream out, int copyBufferSize) {
+    if (copyBufferSize < 0) {
+      throw new IllegalArgumentException("Negative buffer size: " + copyBufferSize);
+    }
+    this.out = out;
+    this.copyBuffer = new byte[copyBufferSize];
+  }
+
+  /**
+   * Write stream into output stream. This merely copies bytes from source into destination and
+   * buffers if possible.
+   * @param in input stream to transfer
+   * @throws IOException
+   */
+  public void writeStream(InputStream in) throws IOException {
+    // TODO: make async read/write
+    int copiedBytes = 0;
+    while (in.available() > 0) {
+      copiedBytes = in.read(copyBuffer, 0, copyBuffer.length);
+      // we are done transferring bytes
+      if (copiedBytes == 0) return;
+      out.write(copyBuffer, 0, copiedBytes);
+    }
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    out.write(b);
+  }
+
+  @Override
+  public void write(byte[] bytes, int offset, int len) throws IOException {
+    out.write(bytes, offset, len);
+  }
+
+  @Override
+  public void write(byte[] bytes) throws IOException {
+    out.write(bytes);
+  }
+
+  @Override
+  public void flush() throws IOException {
+    out.flush();
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+    out.close();
+    copyBuffer = null;
+    out = null;
+  }
+
+  @Override
+  public String toString() {
+    return "FSAppendStream(destination=" + out + ", bufferSize=" + copyBuffer.length + ")";
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/BufferSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/BufferSuite.scala
@@ -152,7 +152,7 @@ class BufferSuite extends UnitTestSuite {
   test("select direct scan buffer on empty stream") {
     withTempDir { dir =>
       // create empty file - this represents stripe bytes, not total data file bytes, because that
-      // would include data file header + metadata + statistics
+      // would include file header + metadata + statistics
       touch(dir / "file")
       val in = open(dir / "file").asInstanceOf[FSDataInputStream]
       val stripes = Array(new StripeInformation(1.toByte, 0, 0, null))
@@ -220,7 +220,7 @@ class BufferSuite extends UnitTestSuite {
   test("select predicate scan buffer on empty stream") {
     withTempDir { dir =>
       // create empty file - this represents stripe bytes, not total data file bytes, because that
-      // would include data file header + metadata + statistics
+      // would include file header + metadata + statistics
       touch(dir / "file")
       val in = open(dir / "file").asInstanceOf[FSDataInputStream]
       val stripes = Array(new StripeInformation(1.toByte, 0, 0, null))

--- a/format/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
@@ -47,8 +47,7 @@ class FileReaderSuite extends UnitTestSuite {
     withTempDir { dir =>
       val path = dir / "file"
       val reader = new FileReader(fs, new Configuration(), path)
-      reader.headerPath() should be (new Path(s"file:$path"))
-      reader.dataPath() should be (new Path(s"file:$path.data"))
+      reader.filePath() should be (new Path(s"file:$path"))
       reader.bufferSize() should be (Riff.Options.BUFFER_SIZE_DEFAULT)
     }
   }
@@ -59,8 +58,7 @@ class FileReaderSuite extends UnitTestSuite {
       val conf = new Configuration()
       conf.setInt(Riff.Options.BUFFER_SIZE, Riff.Options.BUFFER_SIZE_MAX)
       val reader = new FileReader(fs, conf, path)
-      reader.headerPath() should be (new Path(s"file:$path"))
-      reader.dataPath() should be (new Path(s"file:$path.data"))
+      reader.filePath() should be (new Path(s"file:$path"))
       reader.bufferSize() should be (Riff.Options.BUFFER_SIZE_MAX)
     }
   }

--- a/format/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
@@ -46,13 +46,11 @@ class FileWriterSuite extends UnitTestSuite {
       val td = new TypeDescription(StructType(StructField("col", StringType) :: Nil))
       val writer = new FileWriter(fs, conf, path, td, codec)
 
-      writer.headerPath should be (fs.makeQualified(dir / "file"))
-      writer.dataPath should be (fs.makeQualified(dir / "file.data"))
+      writer.filePath should be (fs.makeQualified(dir / "file"))
       writer.numRowsInStripe should be (Riff.Options.STRIPE_ROWS_DEFAULT)
       writer.bufferSize should be (Riff.Options.BUFFER_SIZE_DEFAULT)
       writer.toString should be (
-        s"FileWriter[header=${fs.makeQualified(dir / "file")}, " +
-        s"data=${fs.makeQualified(dir / "file.data")}, " +
+        s"FileWriter[path=${fs.makeQualified(dir / "file")}, " +
         s"type_desc=$td, " +
         s"rows_per_stripe=${Riff.Options.STRIPE_ROWS_DEFAULT}, " +
         s"is_compressed=${codec != null}, " +
@@ -70,13 +68,11 @@ class FileWriterSuite extends UnitTestSuite {
       val td = new TypeDescription(StructType(StructField("col", StringType) :: Nil))
       val writer = new FileWriter(fs, conf, path, td, codec)
 
-      writer.headerPath should be (fs.makeQualified(dir / "file"))
-      writer.dataPath should be (fs.makeQualified(dir / "file.data"))
+      writer.filePath should be (fs.makeQualified(dir / "file"))
       writer.numRowsInStripe should be (Riff.Options.STRIPE_ROWS_DEFAULT)
       writer.bufferSize should be (Riff.Options.BUFFER_SIZE_DEFAULT)
       writer.toString should be (
-        s"FileWriter[header=${fs.makeQualified(dir / "file")}, " +
-        s"data=${fs.makeQualified(dir / "file.data")}, " +
+        s"FileWriter[path=${fs.makeQualified(dir / "file")}, " +
         s"type_desc=$td, " +
         s"rows_per_stripe=${Riff.Options.STRIPE_ROWS_DEFAULT}, " +
         s"is_compressed=${codec != null}, " +
@@ -107,7 +103,7 @@ class FileWriterSuite extends UnitTestSuite {
       val codec: CompressionCodec = null
       val td = new TypeDescription(StructType(StructField("col", StringType) :: Nil))
 
-      touch(path.suffix(".data"))
+      touch(Riff.makeDataPath(path))
       intercept[FileAlreadyExistsException] {
         new FileWriter(fs, conf, path, td, codec)
       }
@@ -174,11 +170,9 @@ class FileWriterSuite extends UnitTestSuite {
         writer.write(InternalRow(UTF8String.fromString(s"$i")))
       }
       writer.finishWrite()
-      val header = fs.getFileStatus(writer.headerPath)
-      val data = fs.getFileStatus(writer.dataPath)
-      // should be greater than header size + header flags
-      assert(header.getLen > 16 + 8)
-      assert(data.getLen > 16)
+      val fileStatus = fs.getFileStatus(writer.filePath)
+      // should be greater than magic + header state
+      assert(fileStatus.getLen > 16)
     }
   }
 
@@ -195,11 +189,9 @@ class FileWriterSuite extends UnitTestSuite {
         writer.write(InternalRow(UTF8String.fromString(s"$i")))
       }
       writer.finishWrite()
-      val header = fs.getFileStatus(writer.headerPath)
-      val data = fs.getFileStatus(writer.dataPath)
-      // should be greater than header size + header flags
-      assert(header.getLen > 16 + 8)
-      assert(data.getLen > 16)
+      val fileStatus = fs.getFileStatus(writer.filePath)
+      // should be greater than magic + header state
+      assert(fileStatus.getLen > 16)
     }
   }
 
@@ -212,11 +204,9 @@ class FileWriterSuite extends UnitTestSuite {
       val writer = new FileWriter(fs, conf, path, td, codec)
       writer.prepareWrite()
       writer.finishWrite()
-      val header = fs.getFileStatus(writer.headerPath)
-      val data = fs.getFileStatus(writer.dataPath)
-      // should be greater than header size + header flags
-      assert(header.getLen > 16 + 8)
-      assert(data.getLen > 16)
+      val fileStatus = fs.getFileStatus(writer.filePath)
+      // should be greater than magic + header state
+      assert(fileStatus.getLen > 16)
     }
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/IndexedRowPerfSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/IndexedRowPerfSuite.scala
@@ -48,7 +48,7 @@ Created file of 20500000 bytes
 
 == Write/read batch of rows ==
 Processing of 100000 records took 280.194 ms
-Data file has 20500000 bytes
+File has 20500000 bytes
 
 == End of performance test suite ==
 */
@@ -155,7 +155,7 @@ class IndexedRowPerfSuite extends UnitTestSuite {
       println()
       println("== Write/read batch of rows ==")
       println(s"Processing of $numRecords records took ${(endTime - startTime) / 1e6} ms")
-      println(s"Data file has $fileSize bytes")
+      println(s"File has $fileSize bytes")
       println()
     }
   }

--- a/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
@@ -117,7 +117,7 @@ class RiffSuite extends UnitTestSuite {
   test("make data path") {
     val path = new Path("/a/b/c")
     val dpath = Riff.makeDataPath(path)
-    dpath should be (new Path("/a/b/c.data"))
+    dpath should be (new Path("/a/b/.c.data"))
   }
 
   test("select column filter enabled") {
@@ -230,14 +230,14 @@ class RiffSuite extends UnitTestSuite {
   test("create file reader") {
     withTempDir { dir =>
       val reader = Riff.reader.create(dir / "file")
-      assert(reader.headerPath.toString == s"file:${dir / "file"}")
+      assert(reader.filePath.toString == s"file:${dir / "file"}")
     }
   }
 
   test("create file reader using path as string") {
     withTempDir { dir =>
       val reader = Riff.reader.create(s"${dir / "file"}")
-      assert(reader.headerPath.toString == s"file:${dir / "file"}")
+      assert(reader.filePath.toString == s"file:${dir / "file"}")
     }
   }
 
@@ -276,6 +276,48 @@ class RiffSuite extends UnitTestSuite {
     }
     rowbuf.close()
     seq
+  }
+
+  test("write/read, with gzip, check stripe info") {
+    withTempDir { dir =>
+      val writer = Riff.writer
+        .setCodec("gzip")
+        .setRowsInStripe(1)
+        .setTypeDesc(schema, "col2")
+        .create(dir / "file")
+      writer.prepareWrite()
+      for (row <- batch) {
+        writer.write(row)
+      }
+      writer.finishWrite()
+
+      val reader = Riff.reader.create(dir / "file")
+      val rowbuf = reader.prepareRead().asInstanceOf[Buffers.InternalRowBuffer]
+      rowbuf.offset() should be (612)
+      rowbuf.getStripes().length should be (5)
+
+      rowbuf.getStripes()(0).offset() should be (0)
+      rowbuf.getStripes()(0).length() should be (36)
+      rowbuf.getStripes()(0).hasStatistics() should be (true)
+
+      rowbuf.getStripes()(1).offset() should be (36)
+      rowbuf.getStripes()(1).length() should be (36)
+      rowbuf.getStripes()(1).hasStatistics() should be (true)
+
+      rowbuf.getStripes()(2).offset() should be (72)
+      rowbuf.getStripes()(2).length() should be (36)
+      rowbuf.getStripes()(2).hasStatistics() should be (true)
+
+      rowbuf.getStripes()(3).offset() should be (108)
+      rowbuf.getStripes()(3).length() should be (36)
+      rowbuf.getStripes()(3).hasStatistics() should be (true)
+
+      rowbuf.getStripes()(4).offset() should be (144)
+      rowbuf.getStripes()(4).length() should be (36)
+      rowbuf.getStripes()(4).hasStatistics() should be (true)
+
+      rowbuf.close()
+    }
   }
 
   // == direct scan ==
@@ -374,7 +416,9 @@ class RiffSuite extends UnitTestSuite {
       val rowbuf = reader.prepareRead(eqt("col2", "def")).asInstanceOf[Buffers.InternalRowBuffer]
       rowbuf.getStripes().length should be (1)
       rowbuf.getStripes()(0).id() should be (1)
-      rowbuf.getStripes()(0).offset() should be (52)
+      // stripe has a relative offset
+      rowbuf.offset() should be (612)
+      rowbuf.getStripes()(0).offset() should be (36)
       rowbuf.getStripes()(0).length() should be (36)
       rowbuf.getStripes()(0).hasStatistics() should be (true)
 

--- a/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
@@ -448,9 +448,8 @@ class RiffSuite extends UnitTestSuite {
       }
       writer.finishWrite()
 
+      // this should skip based on header only
       val reader = Riff.reader.create(dir / "file")
-      // remove data file, this should skip based on header only
-      rm(dir / "file.data", false)
       val rowbuf = reader.prepareRead(eqt("col2", "<none>"))
       rowbuf.isInstanceOf[Buffers.EmptyRowBuffer] should be (true)
       rowbuf.hasNext should be (false)

--- a/format/src/test/scala/com/github/sadikovi/riff/io/FSAppendStreamSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/io/FSAppendStreamSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.io
+
+import java.io.ByteArrayInputStream
+
+import com.github.sadikovi.testutil.implicits._
+import com.github.sadikovi.testutil.UnitTestSuite
+
+class FSAppendStreamSuite extends UnitTestSuite {
+  test("init with wrong copy buffer size") {
+    val err = intercept[IllegalArgumentException] {
+      new FSAppendStream(null, -1)
+    }
+    err.getMessage should be ("Negative buffer size: -1")
+  }
+
+  test("write stream") {
+    val in = new ByteArrayInputStream(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 0))
+    val out = new OutputBuffer()
+    val stream = new FSAppendStream(out, 4)
+    stream.writeStream(in)
+    stream.flush()
+    out.array should be (Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 0))
+  }
+
+  test("write empty stream") {
+    val in = new ByteArrayInputStream(Array[Byte]())
+    val out = new OutputBuffer()
+    val stream = new FSAppendStream(out, 4)
+    stream.writeStream(in)
+    stream.flush()
+    out.array should be (Array[Byte]())
+  }
+
+  test("write stream from file") {
+    withTempDir { dir =>
+      val out = create(dir / "file")
+      out.write(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+      out.close()
+
+      val in = open(dir / "file")
+      val buf = new OutputBuffer()
+      val stream = new FSAppendStream(buf, 4)
+      stream.writeStream(in)
+      in.close()
+      stream.close()
+      buf.array should be (Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
+    }
+  }
+
+  test("write empty stream from file") {
+    withTempDir { dir =>
+      touch(dir / "file")
+      val in = open(dir / "file")
+      val buf = new OutputBuffer()
+      val stream = new FSAppendStream(buf, 4)
+      stream.writeStream(in)
+      in.close()
+      stream.close()
+      buf.array should be (Array[Byte]())
+    }
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/io/StripeInputBufferSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/io/StripeInputBufferSuite.scala
@@ -38,7 +38,7 @@ class StripeInputBufferSuite extends UnitTestSuite {
 
   test("init with empty data array") {
     // this case is perfectly valid, indicates that no records were written
-    // note that stripe metadata is written into header, not data file
+    // note that stripe metadata is written into header of the file
     val buf = new StripeInputBuffer(1.toByte, Array[Byte]())
     buf.length should be (0)
     buf.position should be (0)

--- a/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
+++ b/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
@@ -93,7 +93,6 @@ public class RiffOutputCommitter extends FileOutputCommitter {
 
   /**
    * Filter to read only part files, and discard any files that start with "_" or ".".
-   * We also discard any temporary data files, leaving only correct files to read schema.
    */
   static class PartFileFilter implements PathFilter {
     public static final PartFileFilter instance = new PartFileFilter();
@@ -102,8 +101,7 @@ public class RiffOutputCommitter extends FileOutputCommitter {
 
     @Override
     public boolean accept(Path path) {
-      return !path.getName().startsWith("_") && !path.getName().startsWith(".") &&
-        !path.getName().endsWith(Riff.DATA_FILE_SUFFIX);
+      return !path.getName().startsWith("_") && !path.getName().startsWith(".");
     }
   }
 

--- a/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
+++ b/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
@@ -93,7 +93,7 @@ public class RiffOutputCommitter extends FileOutputCommitter {
 
   /**
    * Filter to read only part files, and discard any files that start with "_" or ".".
-   * We also discard any data files, leaving only headers to read schema.
+   * We also discard any temporary data files, leaving only correct files to read schema.
    */
   static class PartFileFilter implements PathFilter {
     public static final PartFileFilter instance = new PartFileFilter();

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -117,14 +117,14 @@ class DefaultSource
       sparkSession: SparkSession,
       parameters: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    // when inferring schema we expect at least one data file in directory
+    // when inferring schema we expect at least one file in directory
     if (files.isEmpty) {
       log.warn("No paths found for schema inferrence")
       None
     } else {
       // Spark, when returning parsed file paths, does not include metadata files, only files that
-      // are either partitioned or do not begin with "_". This forces us to reconstruct metadata path
-      // manually.
+      // are either partitioned or do not begin with "_". This forces us to reconstruct metadata
+      // path manually.
 
       // Logic is to use "path" key set in parameters map; this is set by DataFrameReader and
       // contains raw unresolved path to the directory or file. We make path qualified and check
@@ -137,7 +137,8 @@ class DefaultSource
         val hdfsPath = new Path(path)
         val fs = hdfsPath.getFileSystem(hadoopConf)
         val qualifiedPath = hdfsPath.makeQualified(fs.getUri, fs.getWorkingDirectory)
-        val reader = Riff.metadataReader.setFileSystem(fs).setConf(hadoopConf).create(qualifiedPath)
+        val reader = Riff.metadataReader.setFileSystem(fs).setConf(hadoopConf)
+          .create(qualifiedPath)
         reader.readMetadataFile(true)
       }
 
@@ -214,40 +215,35 @@ class DefaultSource
     // return iterator of rows
     (file: PartitionedFile) => {
       assert(file.partitionValues.numFields == partitionSchema.size)
-      // because riff stores header and data files separately, we have to ignore data files
-      if (file.filePath.endsWith(Riff.DATA_FILE_SUFFIX)) {
-        Buffers.emptyRowBuffer().asScala
-      } else {
-        val path = new Path(new URI(file.filePath))
-        val hadoopConf = broadcastedHadoopConf.value.value
-        val reader = Riff.reader.setConf(hadoopConf).create(path)
-        val iter = reader.prepareRead(predicate)
-        Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
-        // TODO: this is super inefficient, fix it by applying projection on indexed row
-        if (projectionFields.length < reader.getTypeDescription().size()) {
-          // do projection if we have fewer fields to return
-          new Iterator[InternalRow]() {
-            private val td = reader.getTypeDescription()
+      val path = new Path(new URI(file.filePath))
+      val hadoopConf = broadcastedHadoopConf.value.value
+      val reader = Riff.reader.setConf(hadoopConf).create(path)
+      val iter = reader.prepareRead(predicate)
+      Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
+      // TODO: this is super inefficient, fix it by applying projection on indexed row
+      if (projectionFields.length < reader.getTypeDescription().size()) {
+        // do projection if we have fewer fields to return
+        new Iterator[InternalRow]() {
+          private val td = reader.getTypeDescription()
 
-            override def hasNext: Boolean = {
-              iter.hasNext()
-            }
-
-            override def next: InternalRow = {
-              val row = iter.next()
-              val proj = new ProjectionRow(projectionFields.length)
-              var i = 0
-              while (i < projectionFields.length) {
-                val spec = td.atPosition(td.position(projectionFields(i)))
-                proj.update(i, row.get(spec.position(), spec.dataType()))
-                i += 1
-              }
-              proj
-            }
+          override def hasNext: Boolean = {
+            iter.hasNext()
           }
-        } else {
-          iter.asScala
+
+          override def next: InternalRow = {
+            val row = iter.next()
+            val proj = new ProjectionRow(projectionFields.length)
+            var i = 0
+            while (i < projectionFields.length) {
+              val spec = td.atPosition(td.position(projectionFields(i)))
+              proj.update(i, row.get(spec.position(), spec.dataType()))
+              i += 1
+            }
+            proj
+          }
         }
+      } else {
+        iter.asScala
       }
     }
   }

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -150,9 +150,7 @@ class DefaultSource
         case other =>
           log.info("Failed to load metadata, infer schema from header file")
           // infer schema from the first file in the list
-          val headerFileStatus: Option[FileStatus] = files
-            .filter(!_.getPath.getName.endsWith(Riff.DATA_FILE_SUFFIX))
-            .headOption
+          val headerFileStatus: Option[FileStatus] = files.headOption
           if (headerFileStatus.isEmpty) {
             throw new RuntimeException(s"No header files found in list ${files.toList}")
           }

--- a/sql/src/test/com/github/sadikovi/hadoop/riff/RiffOutputCommitterSuite.scala
+++ b/sql/src/test/com/github/sadikovi/hadoop/riff/RiffOutputCommitterSuite.scala
@@ -38,7 +38,8 @@ class RiffOutputCommitterSuite extends UnitTestSuite {
     PartFileFilter.instance.accept(new Path("/.part-00000.crc")) should be (false)
     // make sure that we filter out Riff temporary data files
     PartFileFilter.instance.accept(new Path("/part-00000.riff")) should be (true)
-    PartFileFilter.instance.accept(new Path("/part-00000.riff.data")) should be (false)
+    PartFileFilter.instance.accept(new Path("/part-00000.riff.data")) should be (true)
+    PartFileFilter.instance.accept(new Path("/.part-00000.riff.data")) should be (false)
   }
 
   test("list files and fetch first found") {

--- a/sql/src/test/com/github/sadikovi/hadoop/riff/RiffOutputCommitterSuite.scala
+++ b/sql/src/test/com/github/sadikovi/hadoop/riff/RiffOutputCommitterSuite.scala
@@ -36,7 +36,7 @@ class RiffOutputCommitterSuite extends UnitTestSuite {
     PartFileFilter.instance.accept(new Path("/_part-00000")) should be (false)
     PartFileFilter.instance.accept(new Path("/_metadata")) should be (false)
     PartFileFilter.instance.accept(new Path("/.part-00000.crc")) should be (false)
-    // make sure that we filter out Riff data files
+    // make sure that we filter out Riff temporary data files
     PartFileFilter.instance.accept(new Path("/part-00000.riff")) should be (true)
     PartFileFilter.instance.accept(new Path("/part-00000.riff.data")) should be (false)
   }


### PR DESCRIPTION
This PR updates code for reader and writer to make create single Riff file with data instead of creating data file and header file. This resulted in removal of file unique id and extending state to 12 bytes. Also all stripes now are written with relative offset instead of absolute and adjusted in row buffer.