### PR TITLE
Add tests for filters and tree state

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/Buffers.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Buffers.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.github.sadikovi.riff.io.CompressionCodec;
 import com.github.sadikovi.riff.io.InStream;
 import com.github.sadikovi.riff.io.StripeInputBuffer;
+import com.github.sadikovi.riff.tree.State;
 
 /**
  * Container for available row buffers.
@@ -67,18 +68,13 @@ public class Buffers {
     } else {
       // resolve state: if state is negative trivial return empty buffer, otherwise choose
       // depending on availability of state
-      if (state != null && !state.isResultKnown()) {
-        rowbuf = new PredicateScanRowBuffer(in, stripes, td, codec, bufferSize, state);
-      } else if (state == null) {
+      LOG.debug("Analyze state {}", state);
+      if (state == null || state.result() == State.True) {
         rowbuf = new DirectScanRowBuffer(in, stripes, td, codec, bufferSize);
+      } else if (state.result() == State.Unknown) {
+        rowbuf = new PredicateScanRowBuffer(in, stripes, td, codec, bufferSize, state);
       } else {
-        // at this point state is known to contain trivial result
-        LOG.debug("Analyze state {}", state);
-        if (state.result()) {
-          rowbuf = new DirectScanRowBuffer(in, stripes, td, codec, bufferSize);
-        } else {
-          rowbuf = new EmptyRowBuffer(in);
-        }
+        rowbuf = new EmptyRowBuffer(in);
       }
     }
     LOG.info("Select row buffer {}", rowbuf);

--- a/format/src/main/java/com/github/sadikovi/riff/tree/BoundReference.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/BoundReference.java
@@ -134,6 +134,11 @@ public abstract class BoundReference implements Tree {
   }
 
   @Override
+  public State state() {
+    return State.Unknown;
+  }
+
+  @Override
   public final boolean analyzed() {
     return ordinal != UNRESOLVED_ORDINAL;
   }

--- a/format/src/main/java/com/github/sadikovi/riff/tree/State.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/State.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree;
+
+/**
+ * Predicate state.
+ * Right now is only reported to capture initial state of the tree.
+ * True state - tree is trivial and results in `true` (filter passes)
+ * False state - tree is trivial and results in `false` (filter does not pass)
+ * Unknown state - tree is not trivial and evaluation is required
+ */
+public enum State {
+  True, False, Unknown;
+
+  /**
+   * Construct trivial state from boolean flag.
+   * Used for Trivial node.
+   * @param result result
+   * @return True or False
+   */
+  public static State trivial(boolean result) {
+    return result ? True : False;
+  }
+
+  /**
+   * Intersection on states.
+   * @param that other state
+   * @return merged state
+   */
+  public State and(State that) {
+    if (this == Unknown || that == Unknown) return Unknown;
+    if (this == False || that == False) return False;
+    return True;
+  }
+
+  /**
+   * Union on states.
+   * @param that other state
+   * @return merged state
+   */
+  public State or(State that) {
+    if (this == True || that == True) return True;
+    if (this == Unknown || that == Unknown) return Unknown;
+    return False;
+  }
+}

--- a/format/src/main/java/com/github/sadikovi/riff/tree/Tree.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/Tree.java
@@ -89,4 +89,12 @@ public interface Tree extends Serializable {
    * @return true if tree is analyzed, false otherwise
    */
   boolean analyzed();
+
+  /**
+   * Return state for the tree.
+   * Each node can return either True, False, or Unknown. True means that tree can be evaluated
+   * without check and has `true` value, similar for `false`. Unknown state means that tree needs
+   * to be evaluated for each row/statistics/filter to determine result.
+   */
+  State state();
 }

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/And.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/And.java
@@ -28,6 +28,7 @@ import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 import com.github.sadikovi.riff.tree.BinaryLogical;
 import com.github.sadikovi.riff.tree.Rule;
+import com.github.sadikovi.riff.tree.State;
 import com.github.sadikovi.riff.tree.Tree;
 
 /**
@@ -72,6 +73,11 @@ public class And extends BinaryLogical {
   @Override
   public Tree transform(Rule rule) {
     return rule.update(this);
+  }
+
+  @Override
+  public State state() {
+    return left.state().and(right.state());
   }
 
   @Override

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/Not.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/Not.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 import com.github.sadikovi.riff.tree.Rule;
+import com.github.sadikovi.riff.tree.State;
 import com.github.sadikovi.riff.tree.Tree;
 import com.github.sadikovi.riff.tree.UnaryLogical;
 
@@ -64,6 +65,12 @@ public class Not extends UnaryLogical {
     // `not` does not evaluate column filters, because child expression evaluation does not
     // guarantee that records for inverse result will not exist in dataset
     return true;
+  }
+
+  @Override
+  public State state() {
+    // state of not predicate is unknown similar to evaluation
+    return State.Unknown;
   }
 
   @Override

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/Or.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/Or.java
@@ -28,6 +28,7 @@ import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 import com.github.sadikovi.riff.tree.BinaryLogical;
 import com.github.sadikovi.riff.tree.Rule;
+import com.github.sadikovi.riff.tree.State;
 import com.github.sadikovi.riff.tree.Tree;
 
 /**
@@ -71,6 +72,11 @@ public class Or extends BinaryLogical {
   @Override
   public Tree transform(Rule rule) {
     return rule.update(this);
+  }
+
+  @Override
+  public State state() {
+    return left.state().or(right.state());
   }
 
   @Override

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/Trivial.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/Trivial.java
@@ -28,6 +28,7 @@ import com.github.sadikovi.riff.ColumnFilter;
 import com.github.sadikovi.riff.Statistics;
 import com.github.sadikovi.riff.TypeDescription;
 import com.github.sadikovi.riff.tree.Rule;
+import com.github.sadikovi.riff.tree.State;
 import com.github.sadikovi.riff.tree.Tree;
 
 /**
@@ -84,6 +85,12 @@ public class Trivial implements Tree {
   public boolean analyzed() {
     // trivial node is always analyzed
     return true;
+  }
+
+  @Override
+  public State state() {
+    // trivial node result is always known
+    return State.trivial(result);
   }
 
   @Override

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
@@ -50,10 +50,10 @@ private[riff] object Filters {
    */
   private def recurBuild(filter: Filter): Tree = {
     filter match {
-      case EqualTo(attribute: String, value: Any) =>
-        eqt(attribute, value)
-      case EqualNullSafe(attribute: String, value: Any) =>
-        // for us we treat `EqualNullSafe` as  `EqualTo` or `IsNull` depending on value
+      case EqualTo(attribute: String, value) =>
+        if (value == null) nvl(attribute) else eqt(attribute, value)
+      case EqualNullSafe(attribute: String, value) =>
+        // for riff we treat `EqualNullSafe` as  `EqualTo` or `IsNull` depending on value
         if (value == null) nvl(attribute) else eqt(attribute, value)
       case GreaterThan(attribute: String, value: Any) =>
         gt(attribute, value)
@@ -65,7 +65,7 @@ private[riff] object Filters {
         le(attribute, value)
       case In(attribute: String, values: Array[Any]) =>
         // scala does not like passing Any into vargs
-        in(attribute, values.map(_.asInstanceOf[AnyRef]))
+        in(attribute, values.map(_.asInstanceOf[AnyRef]): _*)
       case IsNull(attribute: String) =>
         nvl(attribute)
       case IsNotNull(attribute: String) =>

--- a/sql/src/test/com/github/sadikovi/spark/riff/SparkFiltersSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/SparkFiltersSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.spark.riff
+
+import org.apache.spark.sql.sources._
+
+import com.github.sadikovi.riff.tree.FilterApi
+import com.github.sadikovi.riff.tree.FilterApi._
+import com.github.sadikovi.testutil.UnitTestSuite
+
+class SparkFiltersSuite extends UnitTestSuite {
+  test("convert None filter into tree") {
+    Filters.createRiffFilter(None) should be (null)
+  }
+
+  test("convert EqualTo into tree") {
+    Filters.createRiffFilter(Some(EqualTo("col", "abc"))) should be (eqt("col", "abc"))
+    Filters.createRiffFilter(Some(EqualTo("col", 1))) should be (eqt("col", 1))
+    Filters.createRiffFilter(Some(EqualTo("col", 1L))) should be (eqt("col", 1L))
+    Filters.createRiffFilter(Some(EqualTo("col", null))) should be (nvl("col"))
+  }
+
+  test("convert EqualNullSafe into tree") {
+    Filters.createRiffFilter(Some(EqualNullSafe("col", "abc"))) should be (eqt("col", "abc"))
+    Filters.createRiffFilter(Some(EqualNullSafe("col", 1))) should be (eqt("col", 1))
+    Filters.createRiffFilter(Some(EqualNullSafe("col", 1L))) should be (eqt("col", 1L))
+    Filters.createRiffFilter(Some(EqualNullSafe("col", null))) should be (nvl("col"))
+  }
+
+  test("convert GreaterThan into tree") {
+    Filters.createRiffFilter(Some(GreaterThan("col", "abc"))) should be (gt("col", "abc"))
+    Filters.createRiffFilter(Some(GreaterThan("col", 1))) should be (gt("col", 1))
+  }
+
+  test("convert GreaterThanOrEqual into tree") {
+    Filters.createRiffFilter(Some(GreaterThanOrEqual("col", "abc"))) should be (ge("col", "abc"))
+    Filters.createRiffFilter(Some(GreaterThanOrEqual("col", 1))) should be (ge("col", 1))
+  }
+
+  test("convert LessThan into tree") {
+    Filters.createRiffFilter(Some(LessThan("col", "abc"))) should be (lt("col", "abc"))
+    Filters.createRiffFilter(Some(LessThan("col", 1))) should be (lt("col", 1))
+  }
+
+  test("convert LessThanOrEqual into tree") {
+    Filters.createRiffFilter(Some(LessThanOrEqual("col", "abc"))) should be (le("col", "abc"))
+    Filters.createRiffFilter(Some(LessThanOrEqual("col", 1))) should be (le("col", 1))
+  }
+
+  test("convert In into tree") {
+    Filters.createRiffFilter(Some(In("col", Array(1, 2)))) should be (
+      in("col", 1.asInstanceOf[java.lang.Integer], 2.asInstanceOf[java.lang.Integer]))
+    Filters.createRiffFilter(Some(In("col", Array("a", "b")))) should be (in("col", "a", "b"))
+  }
+
+  test("convert IsNull into tree") {
+    Filters.createRiffFilter(Some(IsNull("col"))) should be (nvl("col"))
+  }
+
+  test("convert IsNotNull into tree") {
+    // we do not have IsNotNull tree node, so we convert it into negation of IsNull
+    Filters.createRiffFilter(Some(IsNotNull("col"))) should be (FilterApi.not(nvl("col")))
+  }
+
+  test("convert And into tree") {
+    Filters.createRiffFilter(Some(And(EqualTo("col1", "a"), GreaterThan("col2", 1)))) should be (
+      and(eqt("col1", "a"), gt("col2", 1)))
+    Filters.createRiffFilter(Some(And(IsNotNull("col1"), EqualTo("col1", 1)))) should be (
+      and(FilterApi.not(nvl("col1")), eqt("col1", 1)))
+  }
+
+  test("convert Or into tree") {
+    Filters.createRiffFilter(Some(Or(LessThan("col1", 1L), IsNull("col2")))) should be (
+      or(lt("col1", 1L), nvl("col2")))
+  }
+
+  test("convert Not into tree") {
+    Filters.createRiffFilter(Some(Not(EqualTo("col", 2)))) should be (
+      FilterApi.not(eqt("col", 2)))
+  }
+
+  test("unsupported filters") {
+    Filters.createRiffFilter(Some(StringStartsWith("col", "abc"))) should be (TRUE)
+    Filters.createRiffFilter(Some(StringEndsWith("col", "abc"))) should be (TRUE)
+    Filters.createRiffFilter(Some(StringContains("col", "abc"))) should be (TRUE)
+  }
+}


### PR DESCRIPTION
This PR adds tests for `Filters` and `State` for tree nodes, and fixes some bugs in conversion into Riff filters.  Tree node has a new method `state()` that returns 3 values: True, False, Unknown. This is used to evaluate predicate state and decide on row buffer, because after this point tree will only have 2 possible states and is always analyzed and resolved.