### PR TITLE
Fix setConf method

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -23,6 +23,8 @@
 package com.github.sadikovi.riff;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -225,13 +227,20 @@ public class Riff {
     }
 
     /**
-     * Set configuration.
-     * This replaces current instance configuration.
+     * Set configuration and copies all keys from previous configuration into new one;
+     * the motivation is that configuration might set additional resources.
      * @param conf configuration, must not be null
      * @return this instance
      */
     public T setConf(Configuration conf) {
       if (conf == null) throw new NullPointerException("Configuration is null");
+      // we should set keys from previous configuration only if they do not exist
+      // unfortunately, cannot use `addResource` because of compilation errors
+      Iterator<Map.Entry<String, String>> iter = this.conf.iterator();
+      while (iter.hasNext()) {
+        Map.Entry<String, String> entry = iter.next();
+        conf.setIfUnset(entry.getKey(), entry.getValue());
+      }
       this.conf = conf;
       return this.instance;
     }

--- a/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
@@ -137,6 +137,39 @@ class RiffSuite extends UnitTestSuite {
     }
   }
 
+  test("set conf should include previously set options") {
+    withTempDir { dir =>
+      val conf = new Configuration()
+      val writer = Riff.writer
+        .setTypeDesc(StructType(StructField("a", IntegerType) :: Nil))
+        .setCodec("gzip")
+        .setRowsInStripe(128)
+        .setBufferSize(4 * 1024)
+        .setConf(conf)
+        .create(dir / "path")
+      writer.numRowsInStripe should be (128)
+      writer.bufferSize should be (4 * 1024)
+      writer.codec.isInstanceOf[GzipCodec] should be (true)
+    }
+  }
+
+  test("set conf should overwrite previously set options") {
+    withTempDir { dir =>
+      val conf = new Configuration()
+      conf.setInt(Riff.Options.STRIPE_ROWS, 1024)
+      val writer = Riff.writer
+        .setTypeDesc(StructType(StructField("a", IntegerType) :: Nil))
+        .setCodec("gzip")
+        .setRowsInStripe(128)
+        .setBufferSize(4 * 1024)
+        .setConf(conf)
+        .create(dir / "path")
+      writer.numRowsInStripe should be (1024)
+      writer.bufferSize should be (4 * 1024)
+      writer.codec.isInstanceOf[GzipCodec] should be (true)
+    }
+  }
+
   test("set codec manually") {
     withTempDir { dir =>
       val writer = Riff.writer


### PR DESCRIPTION
This PR fixes `setConf` method on builder. Previously we would just update reference discarding all previously set options. New behaviour is copying all previously set keys into new configuration if they do not exist there. I could not use `addResource` because of compilation errors.