### PR TITLE
Projection update

### DIFF
--- a/sql/src/main/scala/com/github/sadikovi/benchmark/ProjectBenchmark.scala
+++ b/sql/src/main/scala/com/github/sadikovi/benchmark/ProjectBenchmark.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.benchmark
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.types._
+
+import com.github.sadikovi.spark.riff._
+
+object ProjectBenchmark {
+  val schema = StructType(
+    StructField("col1", IntegerType) ::
+    StructField("col2", IntegerType) ::
+    StructField("col3", LongType) ::
+    StructField("col4", LongType) ::
+    StructField("col5", StringType) ::
+    StructField("col6", StringType) ::
+    StructField("col7", StringType) ::
+    StructField("col8", StringType) :: Nil)
+
+  // method to generate dummy row
+  def row(i: Int): Row = {
+    Row(i, i, i.toLong, i.toLong, s"abc$i abc$i abc$i", s"abc$i abc$i abc$i",
+      s"abc$i abc$i abc$i", s"abc$i abc$i abc$i")
+  }
+
+  private def projectBenchmark(spark: SparkSession): Unit = {
+    val valuesPerIteration = 1000000
+    val numPartitions = 50
+
+    val fs = new Path("./temp").getFileSystem(spark.sparkContext.hadoopConfiguration)
+    fs.delete(new Path("./temp/riff-table"), true)
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(0 until valuesPerIteration, numPartitions).map(row), schema)
+    df.write.option("index", "col1,col3,col5").riff("./temp/riff-table")
+
+    val projectBenchmark = new Benchmark("SQL project", valuesPerIteration)
+    projectBenchmark.addCase("Riff (all fields)") { iter =>
+      spark.read.riff("./temp/riff-table").foreach(_ => Unit)
+    }
+
+    projectBenchmark.addCase("Riff (1 field)") { iter =>
+      spark.read.riff("./temp/riff-table").select("col6").foreach(_ => Unit)
+    }
+
+    projectBenchmark.addCase("Riff (3 fields)") { iter =>
+      spark.read.riff("./temp/riff-table").select("col1", "col4", "col6").foreach(_ => Unit)
+    }
+
+    projectBenchmark.addCase("Riff (6 fields)") { iter =>
+      spark.read.riff("./temp/riff-table")
+        .select("col1", "col2", "col4", "col5", "col6", "col8").foreach(_ => Unit)
+    }
+
+    projectBenchmark.run
+  }
+
+  def main(args: Array[String]): Unit = {
+    val sparkConf = new SparkConf().
+      setMaster("local[4]").
+      setAppName("spark-project-benchmark")
+    val spark = SparkSession.builder().config(sparkConf).getOrCreate()
+    projectBenchmark(spark)
+    spark.stop()
+  }
+}

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -223,6 +223,7 @@ class DefaultSource
         // do projection if we have fewer fields to return
         new Iterator[InternalRow]() {
           private val td = reader.getTypeDescription()
+          private val ordinals = projectionFields.map { fieldName => td.position(fieldName) }
 
           override def hasNext: Boolean = {
             iter.hasNext()
@@ -230,10 +231,10 @@ class DefaultSource
 
           override def next: InternalRow = {
             val row = iter.next()
-            val proj = new ProjectionRow(projectionFields.length)
+            val proj = new ProjectionRow(ordinals.length)
             var i = 0
-            while (i < projectionFields.length) {
-              val spec = td.atPosition(td.position(projectionFields(i)))
+            while (i < ordinals.length) {
+              val spec = td.atPosition(ordinals(i))
               proj.update(i, row.get(spec.position(), spec.dataType()))
               i += 1
             }

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -218,13 +218,13 @@ class DefaultSource
       val reader = Riff.reader.setConf(hadoopConf).create(path)
       val iter = reader.prepareRead(predicate)
       Option(TaskContext.get()).foreach(_.addTaskCompletionListener(_ => iter.close()))
-      // TODO: this is super inefficient, fix it by applying projection on indexed row
+      // TODO: this is inefficient, it would be better to apply projection directly on indexed row
       if (projectionFields.length < reader.getTypeDescription().size()) {
         // do projection if we have fewer fields to return
-        new Iterator[InternalRow]() {
-          private val td = reader.getTypeDescription()
-          private val ordinals = projectionFields.map { fieldName => td.position(fieldName) }
+        val td = reader.getTypeDescription()
+        val ordinals = projectionFields.map { fieldName => td.position(fieldName) }
 
+        new Iterator[InternalRow]() {
           override def hasNext: Boolean = {
             iter.hasNext()
           }


### PR DESCRIPTION
This PR updates projection loop in `DefaultSource` to use ordinals instead of field names. Also adds benchmark on projection.

Before:
```
Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL project:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Riff (all fields)                              701 /  785          1.4         700.8       1.0X
Riff (1 field)                                 445 /  477          2.2         445.2       1.6X
Riff (3 fields)                                489 /  546          2.0         488.7       1.4X
Riff (6 fields)                                715 /  734          1.4         714.8       1.0X
```

After:
```
Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL project:                             Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Riff (all fields)                              723 /  794          1.4         722.7       1.0X
Riff (1 field)                                 435 /  463          2.3         435.0       1.7X
Riff (3 fields)                                468 /  506          2.1         467.7       1.5X
Riff (6 fields)                                676 /  684          1.5         676.4       1.1X
```