### PR TITLE
Add snappy compression codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ running `spark.conf.set("option", "value")`.
 
 | Name | Description | Default |
 |------|-------------|---------|
-| `spark.sql.riff.compression.codec` | Compression codec to use for riff (`none`, `gzip`, `deflate`) | `deflate`
+| `spark.sql.riff.compression.codec` | Compression codec to use for riff (`none`, `snappy`, `gzip`, `deflate`) | `deflate`
 | `spark.sql.riff.stripe.rows` | Number of rows to keep per stripe | `10000`
 | `spark.sql.riff.column.filter.enabled` | When enabled, write column filters in addition to min/max/null statistics (`true`, `false`) | `true`
 | `spark.sql.riff.buffer.size` | Buffer size in bytes for out/in stream | `256 * 1024`

--- a/format/src/main/java/com/github/sadikovi/riff/Buffers.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Buffers.java
@@ -265,6 +265,10 @@ public class Buffers {
         if (in != null) {
           in.close();
         }
+        // release codec resources
+        if (codec != null) {
+          codec.close();
+        }
       } catch (IOException ioe) {
         LOG.warn("Exception occuried during release of resources: {}", ioe.getMessage());
       } finally {

--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -387,6 +387,10 @@ public class FileWriter {
       }
       // remove temporary data file
       fs.delete(tmpDataPath, false);
+      // release codec resources
+      if (codec != null) {
+        codec.close();
+      }
     }
     LOG.info("Finished writing file {}", filePath);
     writeFinished = true;

--- a/format/src/main/java/com/github/sadikovi/riff/io/CompressionCodecFactory.java
+++ b/format/src/main/java/com/github/sadikovi/riff/io/CompressionCodecFactory.java
@@ -40,6 +40,10 @@ public class CompressionCodecFactory {
   public static final String GZIP_FILE_EXTENSION = ".gz";
   public static final String GZIP_SHORT_NAME = "gzip";
   public static final byte GZIP_ENCODE_FLAG = 2;
+  // constants for snappy codec
+  public static final String SNAPPY_FILE_EXTENSION = ".snappy";
+  public static final String SNAPPY_SHORT_NAME = "snappy";
+  public static final byte SNAPPY_ENCODE_FLAG = 3;
 
   private CompressionCodecFactory() { }
 
@@ -53,6 +57,7 @@ public class CompressionCodecFactory {
     if (codec == UNCOMPRESSED) return UNCOMPRESSED_ENCODE_FLAG;
     if (codec instanceof ZlibCodec) return ZLIB_ENCODE_FLAG;
     if (codec instanceof GzipCodec) return GZIP_ENCODE_FLAG;
+    if (codec instanceof SnappyCodec) return SNAPPY_ENCODE_FLAG;
     throw new UnsupportedOperationException("Unknown codec: " + codec);
   }
 
@@ -66,6 +71,7 @@ public class CompressionCodecFactory {
     // return zlib codec with default settings
     if (flag == ZLIB_ENCODE_FLAG) return new ZlibCodec();
     if (flag == GZIP_ENCODE_FLAG) return new GzipCodec();
+    if (flag == SNAPPY_ENCODE_FLAG) return new SnappyCodec();
     throw new UnsupportedOperationException("Unknown codec flag: " + flag);
   }
 
@@ -80,6 +86,8 @@ public class CompressionCodecFactory {
         return new ZlibCodec();
       case GZIP_SHORT_NAME:
         return new GzipCodec();
+      case SNAPPY_SHORT_NAME:
+        return new SnappyCodec();
       case UNCOMPRESSED_SHORT_NAME:
         return UNCOMPRESSED;
       default:
@@ -90,7 +98,7 @@ public class CompressionCodecFactory {
   /**
    * Get codec for file extension.
    * If extension is unknown uncompressed codec is returned.
-   * @param ext file extension, e.g. ".gz", ".deflate"
+   * @param ext file extension, e.g. ".gz", ".deflate", ".snappy"
    * @return compression codec
    */
   public static CompressionCodec forFileExt(String ext) {
@@ -99,6 +107,8 @@ public class CompressionCodecFactory {
         return new ZlibCodec();
       case GZIP_FILE_EXTENSION:
         return new GzipCodec();
+      case SNAPPY_FILE_EXTENSION:
+        return new SnappyCodec();
       default:
         return UNCOMPRESSED;
     }
@@ -116,6 +126,8 @@ public class CompressionCodecFactory {
         return ZLIB_FILE_EXTENSION;
       case GZIP_SHORT_NAME:
         return GZIP_FILE_EXTENSION;
+      case SNAPPY_SHORT_NAME:
+        return SNAPPY_FILE_EXTENSION;
       case UNCOMPRESSED_SHORT_NAME:
         return UNCOMPRESSED_FILE_EXTENSION;
       default:

--- a/format/src/main/java/com/github/sadikovi/riff/io/SnappyCodec.java
+++ b/format/src/main/java/com/github/sadikovi/riff/io/SnappyCodec.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.io;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.xerial.snappy.Snappy;
+
+public class SnappyCodec implements CompressionCodec {
+  // snappy size for temporary buffer
+  private static final int SNAPPY_BUFFER_SIZE = 4096;
+  // temporary byte array to reuse between compress calls
+  private byte[] buffer;
+
+  public SnappyCodec() {
+    // snappy buffer size is default size, it is reallocated if we need larger buffer
+    this.buffer = new byte[SNAPPY_BUFFER_SIZE];
+  }
+
+  @Override
+  public boolean compress(ByteBuffer in, ByteBuffer out, ByteBuffer overflow) throws IOException {
+    // find out approximate number of bytes we need for compression, note that this number can be
+    // higher than input size, but actual compressed bytes are smaller than input size
+    int compressedBytes = Snappy.maxCompressedLength(in.remaining());
+    // resize buffer if necessary
+    if (buffer.length < compressedBytes) {
+      buffer = new byte[compressedBytes];
+    }
+    // compress into allocated array and update compressed bytes
+    compressedBytes = Snappy.compress(in.array(), in.arrayOffset() + in.position(),
+      in.remaining(), buffer, 0);
+    // check if it is still better to keep data compressed, this check is done assuming that in
+    // buffer is not modified until this point
+    if (compressedBytes >= in.remaining()) {
+      out.position(out.limit());
+      if (overflow != null) {
+        overflow.position(overflow.limit());
+      }
+      return false;
+    } else {
+      // copy bytes into out and overflow buffers
+      int len = Math.min(compressedBytes, out.remaining());
+      out.put(buffer, 0, len);
+      compressedBytes -= len;
+      if (compressedBytes > 0) {
+        if (overflow == null || overflow.remaining() == 0) return false;
+        overflow.put(buffer, len, compressedBytes);
+      }
+      return true;
+    }
+  }
+
+  @Override
+  public void decompress(ByteBuffer in, ByteBuffer out) throws IOException {
+    int uncompressedBytes = Snappy.uncompressedLength(in.array(), in.arrayOffset() + in.position(),
+      in.remaining());
+    if (uncompressedBytes > out.remaining()) {
+      throw new IOException("Output buffer is too short, could not insert more bytes from " +
+        "compressed byte buffer");
+    }
+    // this does not update positions in in or out buffers, we will have to do manually after
+    // decompression.
+    uncompressedBytes = Snappy.uncompress(in.array(), in.arrayOffset() + in.position(),
+      in.remaining(), out.array(), out.arrayOffset() + out.position());
+    out.position(out.position() + uncompressedBytes);
+    // prepare for read
+    out.flip();
+    in.position(in.limit());
+  }
+
+  @Override
+  public void reset() {
+    // no-op
+  }
+
+  @Override
+  public void close() {
+    buffer = null;
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
@@ -326,6 +326,20 @@ class RiffSuite extends UnitTestSuite {
 
   // == direct scan ==
 
+  test("write/read with snappy, direct scan") {
+    withTempDir { dir =>
+      val res = writeReadTest(new SnappyCodec(), dir / "file")
+      res.length should be (batch.length)
+      for (i <- 0 until res.length) {
+        val row1 = res(i)
+        val row2 = batch(i)
+        row1.getUTF8String(0) should be (row2.getUTF8String(1))
+        row1.getInt(1) should be (row2.getInt(0))
+        row1.getLong(2) should be (row2.getLong(2))
+      }
+    }
+  }
+
   test("write/read with gzip, direct scan") {
     withTempDir { dir =>
       val res = writeReadTest(new GzipCodec(), dir / "file")
@@ -369,6 +383,17 @@ class RiffSuite extends UnitTestSuite {
   }
 
   // == filter scan ==
+
+  test("write/read with snappy, filter scan") {
+    withTempDir { dir =>
+      val filter = eqt("col2", "def")
+      val res = writeReadTest(new SnappyCodec(), dir / "file", filter)
+      res.length should be (1)
+      res(0).getUTF8String(0) should be (UTF8String.fromString("def"))
+      res(0).getInt(1) should be (2)
+      res(0).getLong(2) should be (2L)
+    }
+  }
 
   test("write/read with gzip, filter scan") {
     withTempDir { dir =>

--- a/format/src/test/scala/com/github/sadikovi/riff/io/CompressionCodecFactorySuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/io/CompressionCodecFactorySuite.scala
@@ -31,6 +31,7 @@ class CompressionCodecFactorySuite extends UnitTestSuite {
     CompressionCodecFactory.encode(CompressionCodecFactory.UNCOMPRESSED) should be (0)
     CompressionCodecFactory.encode(new ZlibCodec()) should be (1)
     CompressionCodecFactory.encode(new GzipCodec()) should be (2)
+    CompressionCodecFactory.encode(new SnappyCodec()) should be (3)
   }
 
   test("encode unknown codec") {
@@ -50,6 +51,7 @@ class CompressionCodecFactorySuite extends UnitTestSuite {
     assert(CompressionCodecFactory.decode(0) == CompressionCodecFactory.UNCOMPRESSED)
     assert(CompressionCodecFactory.decode(1).isInstanceOf[ZlibCodec])
     assert(CompressionCodecFactory.decode(2).isInstanceOf[GzipCodec])
+    assert(CompressionCodecFactory.decode(3).isInstanceOf[SnappyCodec])
   }
 
   test("decode unknown flag") {
@@ -63,10 +65,12 @@ class CompressionCodecFactorySuite extends UnitTestSuite {
     assert(CompressionCodecFactory.forShortName("none") == CompressionCodecFactory.UNCOMPRESSED)
     assert(CompressionCodecFactory.forShortName("deflate").isInstanceOf[ZlibCodec])
     assert(CompressionCodecFactory.forShortName("gzip").isInstanceOf[GzipCodec])
+    assert(CompressionCodecFactory.forShortName("snappy").isInstanceOf[SnappyCodec])
 
     assert(CompressionCodecFactory.forShortName("NONE") == CompressionCodecFactory.UNCOMPRESSED)
     assert(CompressionCodecFactory.forShortName("DEFLATE").isInstanceOf[ZlibCodec])
     assert(CompressionCodecFactory.forShortName("GZIP").isInstanceOf[GzipCodec])
+    assert(CompressionCodecFactory.forShortName("SNAPPY").isInstanceOf[SnappyCodec])
   }
 
   test("codec for unknown short name") {
@@ -79,6 +83,7 @@ class CompressionCodecFactorySuite extends UnitTestSuite {
   test("codec for file extension") {
     assert(CompressionCodecFactory.forFileExt(".deflate").isInstanceOf[ZlibCodec])
     assert(CompressionCodecFactory.forFileExt(".gz").isInstanceOf[GzipCodec])
+    assert(CompressionCodecFactory.forFileExt(".snappy").isInstanceOf[SnappyCodec])
 
     assert(CompressionCodecFactory.forFileExt("none") == CompressionCodecFactory.UNCOMPRESSED)
     assert(CompressionCodecFactory.forFileExt("") == CompressionCodecFactory.UNCOMPRESSED)
@@ -89,6 +94,8 @@ class CompressionCodecFactorySuite extends UnitTestSuite {
     CompressionCodecFactory.fileExtForShortName("DEFLATE") should be (".deflate")
     CompressionCodecFactory.fileExtForShortName("gzip") should be (".gz")
     CompressionCodecFactory.fileExtForShortName("GZIP") should be (".gz")
+    CompressionCodecFactory.fileExtForShortName("snappy") should be (".snappy")
+    CompressionCodecFactory.fileExtForShortName("SNAPPY") should be (".snappy")
     CompressionCodecFactory.fileExtForShortName("none") should be ("")
     CompressionCodecFactory.fileExtForShortName("NONE") should be ("")
   }

--- a/format/src/test/scala/com/github/sadikovi/riff/io/SnappyCodecSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/io/SnappyCodecSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.io
+
+import java.io.IOException
+import java.nio.ByteBuffer
+
+import com.github.sadikovi.testutil.UnitTestSuite
+
+class SnappyCodecSuite extends UnitTestSuite {
+  test("fill up compressed and overflow buffers and exit loop correctly") {
+    val inbuf = ByteBuffer.wrap(Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+    val outbuf = ByteBuffer.allocate(8)
+    val overflow = ByteBuffer.allocate(8)
+    val codec = new SnappyCodec()
+    codec.compress(inbuf, outbuf, overflow) should be (false)
+    outbuf.remaining() should be (0)
+    overflow.remaining() should be (0)
+  }
+
+  test("compress and decompress byte array with large result buffer") {
+    val inbuf = ByteBuffer.allocate(128)
+    while (inbuf.remaining() != 0) {
+      inbuf.putLong(inbuf.remaining())
+    }
+    inbuf.flip()
+    val outbuf = ByteBuffer.allocate(128)
+    val codec = new SnappyCodec()
+    codec.compress(inbuf, outbuf, null) should be (true)
+    outbuf.flip()
+
+    // result buffer is larger than original input buffer to test full read
+    val resbuf = ByteBuffer.allocate(256)
+    codec.decompress(outbuf, resbuf)
+    resbuf.array().slice(0, 128) should be (inbuf.array())
+  }
+
+  test("compress and decompress on buffer size boundary") {
+    val inbuf = ByteBuffer.allocate(128)
+    while (inbuf.remaining() != 0) {
+      inbuf.putLong(inbuf.remaining())
+    }
+    inbuf.flip()
+    val outbuf = ByteBuffer.allocate(128)
+    val codec = new SnappyCodec()
+    codec.compress(inbuf, outbuf, null) should be (true)
+    outbuf.flip()
+
+    val resbuf = ByteBuffer.allocate(128)
+    codec.decompress(outbuf, resbuf)
+    resbuf.array() should be (inbuf.array())
+  }
+
+  test("compress and decompress with overflow spill") {
+    val inbuf = ByteBuffer.allocate(128)
+    while (inbuf.remaining() != 0) {
+      inbuf.putLong(inbuf.remaining())
+    }
+    inbuf.flip()
+    // there are 65 bytes in total
+    val outbuf = ByteBuffer.allocate(32)
+    val overflow = ByteBuffer.allocate(64)
+    val codec = new SnappyCodec()
+    codec.compress(inbuf, outbuf, overflow) should be (true)
+    outbuf.flip()
+    overflow.flip()
+    val mergebuf = ByteBuffer.allocate(outbuf.remaining + overflow.remaining)
+    mergebuf.put(outbuf)
+    mergebuf.put(overflow)
+    mergebuf.flip()
+
+    val resbuf = ByteBuffer.allocate(128)
+    codec.decompress(mergebuf, resbuf)
+    resbuf.array() should be (inbuf.array())
+  }
+
+  test("compress and decompress byte array using smaller output buffer") {
+    val inbuf = ByteBuffer.allocate(128)
+    while (inbuf.remaining() != 0) {
+      inbuf.putLong(inbuf.remaining())
+    }
+    inbuf.flip()
+    val outbuf = ByteBuffer.allocate(128)
+    val codec = new SnappyCodec()
+    codec.compress(inbuf, outbuf, null) should be (true)
+    outbuf.flip()
+
+    val resbuf = ByteBuffer.allocate(64)
+    val err = intercept[IOException] {
+      codec.decompress(outbuf, resbuf)
+    }
+    err.getMessage should be ("Output buffer is too short, could not insert more bytes from " +
+      "compressed byte buffer")
+  }
+}

--- a/sql/src/main/scala/com/github/sadikovi/benchmark/WriteBenchmark.scala
+++ b/sql/src/main/scala/com/github/sadikovi/benchmark/WriteBenchmark.scala
@@ -77,6 +77,13 @@ object WriteBenchmark {
       df.write.mode("overwrite").option("index", "col1,col3,col5").riff("./temp/riff-table")
     }
 
+    writeBenchmark.addCase("Riff write (+column filters), snappy") { iter =>
+      spark.conf.set("spark.sql.riff.compression.codec", "snappy")
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(0 until valuesPerIteration, numPartitions).map(row), schema)
+      df.write.mode("overwrite").option("index", "col1,col3,col5").riff("./temp/riff-table")
+    }
+
     writeBenchmark.run
   }
 


### PR DESCRIPTION
This PR adds `SnappyCodec` and tests for it, updates benchmark and README to include snappy compression.

Benchmark results:
```
Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL Write:                               Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Parquet write, gzip                           7426 / 7959          0.1        7426.2       1.0X
ORC write, zlib/deflate                       4652 / 4787          0.2        4652.4       1.6X
Riff write (+column filters), gzip            4906 / 4977          0.2        4905.6       1.5X
Riff write (+column filters), deflate         4828 / 4858          0.2        4828.4       1.5X
Riff write (+column filters), snappy          2743 / 2849          0.4        2742.5       2.7X
```