### PR TITLE
Improve read performance of Riff

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/Metadata.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Metadata.java
@@ -99,7 +99,7 @@ public class Metadata {
      * Create instance of metadata wrtier for a Riff file.
      * @param fs file system to use
      * @param conf hadoop configuration with riff settings
-     * @param filepath Riff filepath to a valid header file
+     * @param filepath filepath to a valid Riff file
      */
     public MetadataWriter(FileSystem fs, Configuration conf, Path filepath) throws IOException {
       // infer metadata path and read header file

--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -230,7 +230,9 @@ public class Riff {
       codec = inferCompressionCodec(path);
     }
     try {
-      return new FileWriter(fs, conf, path, td, codec);
+      FileWriter writer = new FileWriter(fs, conf, path, td, codec);
+      LOG.info("Created writer {}", writer);
+      return writer;
     } catch (IOException err) {
       throw new RuntimeException("Error occured: " + err.getMessage(), err);
     }
@@ -275,7 +277,9 @@ public class Riff {
    * @return file reader
    */
   public static FileReader reader(FileSystem fs, Configuration conf, Path path) {
-    return new FileReader(fs, conf, path);
+    FileReader reader = new FileReader(fs, conf, path);
+    LOG.info("Created reader {}", reader);
+    return reader;
   }
 
   /**

--- a/format/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/FileReaderSuite.scala
@@ -137,12 +137,12 @@ class FileReaderSuite extends UnitTestSuite {
 
   test("file reader reuse") {
     withTempDir { dir =>
-      val writer = Riff.writer.setTypeDesc(td).create(dir / "path")
+      val writer = Riff.writer(dir / "path", td)
       writer.prepareWrite()
       writer.finishWrite()
 
       // test prepareRead
-      val reader1 = Riff.reader.create(dir / "path")
+      val reader1 = Riff.reader(dir / "path")
       reader1.prepareRead()
       var err = intercept[IOException] { reader1.prepareRead() }
       err.getMessage should be ("Reader reuse")
@@ -150,7 +150,7 @@ class FileReaderSuite extends UnitTestSuite {
       err.getMessage should be ("Reader reuse")
 
       // test readTypeDescription
-      val reader2 = Riff.reader.create(dir / "path")
+      val reader2 = Riff.reader(dir / "path")
       reader2.readFileHeader()
       err = intercept[IOException] { reader2.readFileHeader() }
       err.getMessage should be ("Reader reuse")
@@ -161,11 +161,11 @@ class FileReaderSuite extends UnitTestSuite {
 
   test("read file header") {
     withTempDir { dir =>
-      val writer = Riff.writer.setTypeDesc(td).create(dir / "path")
+      val writer = Riff.writer(dir / "path", td)
       writer.prepareWrite()
       writer.finishWrite()
 
-      val reader = Riff.reader.create(dir / "path")
+      val reader = Riff.reader(dir / "path")
       val td1 = reader.readFileHeader()
       val td2 = reader.getFileHeader()
       td1.getTypeDescription() should be (td)
@@ -177,7 +177,7 @@ class FileReaderSuite extends UnitTestSuite {
 
   test("fail to get type description if it is not set") {
     withTempDir { dir =>
-      val reader = Riff.reader.create(dir / "path")
+      val reader = Riff.reader(dir / "path")
       val err = intercept[IllegalStateException] {
         reader.getFileHeader()
       }

--- a/format/src/test/scala/com/github/sadikovi/riff/MetadataSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/MetadataSuite.scala
@@ -33,11 +33,12 @@ class MetadataSuite extends UnitTestSuite {
   test("write metadata for a file with provided file path as output") {
     withTempDir { dir =>
       val schema = StructType(StructField("a", IntegerType) :: Nil)
-      val writer = Riff.writer.setTypeDesc(schema).create(dir / "file")
+      val td = new TypeDescription(schema)
+      val writer = Riff.writer(dir / "file", td)
       writer.prepareWrite()
       writer.finishWrite()
       // create metadata for a file
-      val mwriter = Riff.metadataWriter.create(dir / "file")
+      val mwriter = Riff.metadataWriter(dir / "file")
       mwriter.writeMetadataFile(dir / "file")
 
       fs.exists(dir / Metadata.METADATA_FILENAME) should be (true)
@@ -47,11 +48,12 @@ class MetadataSuite extends UnitTestSuite {
   test("write metadata for a file with provided file directory as output") {
     withTempDir { dir =>
       val schema = StructType(StructField("a", IntegerType) :: Nil)
-      val writer = Riff.writer.setTypeDesc(schema).create(dir / "file")
+      val td = new TypeDescription(schema)
+      val writer = Riff.writer(dir / "file", td)
       writer.prepareWrite()
       writer.finishWrite()
       // create metadata for a file
-      val mwriter = Riff.metadataWriter.create(dir / "file")
+      val mwriter = Riff.metadataWriter(dir / "file")
       mwriter.writeMetadataFile(dir)
 
       fs.exists(dir / Metadata.METADATA_FILENAME) should be (true)
@@ -61,14 +63,15 @@ class MetadataSuite extends UnitTestSuite {
   test("write/read metadata for a file") {
     withTempDir { dir =>
       val schema = StructType(StructField("a", IntegerType) :: Nil)
-      val writer = Riff.writer.setTypeDesc(schema).create(dir / "file")
+      val td = new TypeDescription(schema)
+      val writer = Riff.writer(dir / "file", td)
       writer.prepareWrite()
       writer.finishWrite()
       // create metadata for a file
-      val mwriter = Riff.metadataWriter.create(dir / "file")
+      val mwriter = Riff.metadataWriter(dir / "file")
       mwriter.writeMetadataFile(dir)
 
-      val mreader = Riff.metadataReader.create(dir)
+      val mreader = Riff.metadataReader(dir)
       val metadata = mreader.readMetadataFile(false)
 
       metadata.getTypeDescription should be (new TypeDescription(schema))
@@ -78,14 +81,15 @@ class MetadataSuite extends UnitTestSuite {
   test("write/read metadata for a file, direct path") {
     withTempDir { dir =>
       val schema = StructType(StructField("a", IntegerType) :: Nil)
-      val writer = Riff.writer.setTypeDesc(schema).create(dir / "file")
+      val td = new TypeDescription(schema)
+      val writer = Riff.writer(dir / "file", td)
       writer.prepareWrite()
       writer.finishWrite()
       // create metadata for a file
-      val mwriter = Riff.metadataWriter.create(dir / "file")
+      val mwriter = Riff.metadataWriter(dir / "file")
       mwriter.writeMetadataFile(dir)
 
-      val mreader = Riff.metadataReader.create(dir / Metadata.METADATA_FILENAME)
+      val mreader = Riff.metadataReader(dir / Metadata.METADATA_FILENAME)
       val metadata = mreader.readMetadataFile(false)
 
       metadata.getTypeDescription should be (new TypeDescription(schema))
@@ -94,7 +98,7 @@ class MetadataSuite extends UnitTestSuite {
 
   test("ignore metadata if file is not found in directory") {
     withTempDir { dir =>
-      val mreader = Riff.metadataReader.create(dir)
+      val mreader = Riff.metadataReader(dir)
       val metadata = mreader.readMetadataFile(true)
       metadata should be (null)
     }
@@ -102,7 +106,7 @@ class MetadataSuite extends UnitTestSuite {
 
   test("ignore metadata if file is not found, direct path") {
     withTempDir { dir =>
-      val mreader = Riff.metadataReader.create(dir / Metadata.METADATA_FILENAME)
+      val mreader = Riff.metadataReader(dir / Metadata.METADATA_FILENAME)
       val metadata = mreader.readMetadataFile(true)
       metadata should be (null)
     }
@@ -110,7 +114,7 @@ class MetadataSuite extends UnitTestSuite {
 
   test("fail to read metadata if file is not found and ignoreNotFound is false") {
     withTempDir { dir =>
-      val mreader = Riff.metadataReader.create(dir / Metadata.METADATA_FILENAME)
+      val mreader = Riff.metadataReader(dir / Metadata.METADATA_FILENAME)
       val err = intercept[IOException] {
         mreader.readMetadataFile(false)
       }

--- a/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
+++ b/sql/src/main/java/com/github/sadikovi/hadoop/riff/RiffOutputCommitter.java
@@ -84,8 +84,7 @@ public class RiffOutputCommitter extends FileOutputCommitter {
     if (partFiles.isEmpty()) {
       LOG.warn("Could not find any part files for path {}, metadata is ignored", outputPath);
     } else {
-      Metadata.MetadataWriter writer = Riff.metadataWriter().setFileSystem(fs).setConf(conf)
-        .create(partFiles.get(0).getPath());
+      Metadata.MetadataWriter writer = Riff.metadataWriter(fs, conf, partFiles.get(0).getPath());
       writer.writeMetadataFile(outputPath);
       LOG.info("Finished writing metadata file for {}", outputPath);
     }

--- a/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
+++ b/sql/src/main/scala/org/apache/spark/sql/riff/RiffOutputWriter.scala
@@ -99,10 +99,7 @@ class RiffOutputWriter(
     new Path(path)
   }
   // prepare riff writer, all options should be set through hadoop configuration
-  val writer = Riff.writer
-    .setTypeDesc(typeDesc)
-    .setConf(configuration)
-    .create(filepath)
+  val writer = Riff.writer(configuration, filepath, typeDesc)
   writer.prepareWrite()
 
   override def write(row: Row): Unit = {


### PR DESCRIPTION
This PR updates initialization of file reader and writer to remove recursive calls and improve overall performance. As per #54, GC situation has improved and now is comparable with Parquet. I will post benchmarks later, but query update looks like this:
Before patch:
```
Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL Query (int filter, one record):      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Parquet                                        230 /  272          4.3         230.1       1.0X
ORC                                            757 /  817          1.3         757.4       0.3X
Riff                                           511 /  867          2.0         510.8       0.5X


Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL Query (string filter, one record):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Parquet                                        456 /  528          2.2         455.7       1.0X
ORC                                            753 /  910          1.3         753.4       0.6X
Riff                                           361 /  402          2.8         360.7       1.3X
```

After patch:
```
Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL Query (int filter, one record):      Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Parquet                                        231 /  251          4.3         231.1       1.0X
ORC                                            745 /  789          1.3         745.5       0.3X
Riff                                            67 /   76         14.9          67.2       3.4X

Java HotSpot(TM) 64-Bit Server VM 1.7.0_80-b15 on Mac OS X 10.12.4
Intel(R) Core(TM) i5-4258U CPU @ 2.40GHz
SQL Query (string filter, one record):   Best/Avg Time(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------
Parquet                                        349 /  375          2.9         349.4       1.0X
ORC                                            702 /  735          1.4         702.3       0.5X
Riff                                            66 /   71         15.2          65.7       5.3X
```

PR also changes Riff API for creating reader/writer/metadata writer/metadata reader.
Benchmarks are updated in gist.