### PR TITLE
Add DateType and TimestampType support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ These options that you can specify when writing DataFrame by calling `df.write.o
 |------|-------------|---------|
 | `index` | Optional setting to specify columns to index by Riff; if no columns provided, default row layout is used | `<empty string>`
 
+## Supported Spark SQL types
+- `IntegerType`
+- `LongType`
+- `StringType`
+- `DateType`
+- `TimestampType`
+
 ## Example
 Usage is very similar to other datasources for Spark, e.g. Parquet, ORC, JSON, etc. Riff allows to
 set some datasource options in addition to ones listed in the table above.

--- a/format/src/main/java/com/github/sadikovi/riff/Buffers.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Buffers.java
@@ -77,7 +77,7 @@ public class Buffers {
         rowbuf = new EmptyRowBuffer(in);
       }
     }
-    LOG.info("Select row buffer {}", rowbuf);
+    LOG.debug("Select row buffer {}", rowbuf);
     return rowbuf;
   }
 
@@ -300,7 +300,7 @@ public class Buffers {
         int bufferSize) throws IOException {
       super(in, stripes, codec, bufferSize);
       this.reader = new IndexedRowReader(td);
-      LOG.info("Created reader {}", reader);
+      LOG.debug("Created reader {}", reader);
     }
 
     @Override
@@ -351,7 +351,7 @@ public class Buffers {
         PredicateState state) throws IOException {
       super(in, stripes, codec, bufferSize);
       this.reader = new IndexedRowReader(td);
-      LOG.info("Created reader {}", reader);
+      LOG.debug("Created reader {}", reader);
       this.state = state;
       this.found = false;
       this.currentRow = null;

--- a/format/src/main/java/com/github/sadikovi/riff/ColumnFilter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/ColumnFilter.java
@@ -27,9 +27,11 @@ import java.nio.ByteBuffer;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.util.sketch.BloomFilter;
 
@@ -116,6 +118,22 @@ public abstract class ColumnFilter {
         @Override
         public void update(InternalRow row, int ordinal) {
           filter.putBinary(row.getUTF8String(ordinal).getBytes());
+        }
+      };
+    } else if (dataType instanceof DateType) {
+      // date type is kept as integer in Spark SQL
+      return new BloomColumnFilter(numItems) {
+        @Override
+        public void update(InternalRow row, int ordinal) {
+          filter.putLong(row.getInt(ordinal));
+        }
+      };
+    } else if (dataType instanceof TimestampType) {
+      // timestamp type is kept as long in Spark SQL
+      return new BloomColumnFilter(numItems) {
+        @Override
+        public void update(InternalRow row, int ordinal) {
+          filter.putLong(row.getLong(ordinal));
         }
       };
     } else {

--- a/format/src/main/java/com/github/sadikovi/riff/Converters.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Converters.java
@@ -26,9 +26,11 @@ import java.io.IOException;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
 
 import com.github.sadikovi.riff.io.OutputBuffer;
 
@@ -48,6 +50,10 @@ public class Converters {
       return new IndexedRowLongConverter();
     } else if (dataType instanceof StringType) {
       return new IndexedRowUTF8Converter();
+    } else if (dataType instanceof DateType) {
+      return new IndexedRowIntConverter();
+    } else if (dataType instanceof TimestampType) {
+      return new IndexedRowLongConverter();
     } else {
       throw new RuntimeException("No converter registered for type " + dataType);
     }

--- a/format/src/main/java/com/github/sadikovi/riff/IndexedRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/IndexedRow.java
@@ -27,10 +27,12 @@ import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -225,6 +227,10 @@ final class IndexedRow extends GenericInternalRow {
       return getLong(ordinal);
     } else if (dataType instanceof StringType) {
       return getUTF8String(ordinal);
+    } else if (dataType instanceof DateType) {
+      return getInt(ordinal);
+    } else if (dataType instanceof TimestampType) {
+      return getLong(ordinal);
     } else {
       throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
@@ -26,10 +26,12 @@ import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.NullType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -147,6 +149,10 @@ public class ProjectionRow extends GenericInternalRow {
       return getLongValue(ordinal);
     } else if (dataType instanceof StringType) {
       return getUTF8String(ordinal);
+    } else if (dataType instanceof DateType) {
+      return getIntegerValue(ordinal);
+    } else if (dataType instanceof TimestampType) {
+      return getLongValue(ordinal);
     } else {
       throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/Statistics.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Statistics.java
@@ -27,9 +27,11 @@ import java.nio.ByteBuffer;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import com.github.sadikovi.riff.io.OutputBuffer;
@@ -164,6 +166,10 @@ public abstract class Statistics extends GenericInternalRow {
       return new LongStatistics();
     } else if (dataType instanceof StringType) {
       return new UTF8StringStatistics();
+    } else if (dataType instanceof DateType) {
+      return new IntStatistics();
+    } else if (dataType instanceof TimestampType) {
+      return new LongStatistics();
     } else {
       return new NoopStatistics();
     }

--- a/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
+++ b/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
@@ -36,11 +36,13 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampType;
 
 /**
  * Internal schema specification based on Spark SQL schema, that acts as proxy to write and read
@@ -156,7 +158,9 @@ public class TypeDescription implements Externalizable {
     return
       (dataType instanceof IntegerType) ||
       (dataType instanceof LongType) ||
-      (dataType instanceof StringType);
+      (dataType instanceof StringType) ||
+      (dataType instanceof DateType) ||
+      (dataType instanceof TimestampType);
   }
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
@@ -22,10 +22,15 @@
 
 package com.github.sadikovi.riff.tree;
 
+import java.sql.Date;
+import java.sql.Timestamp;
+
 import org.apache.spark.unsafe.types.UTF8String;
 
+import com.github.sadikovi.riff.tree.expression.DateExpression;
 import com.github.sadikovi.riff.tree.expression.IntegerExpression;
 import com.github.sadikovi.riff.tree.expression.LongExpression;
+import com.github.sadikovi.riff.tree.expression.TimestampExpression;
 import com.github.sadikovi.riff.tree.expression.UTF8StringExpression;
 
 import com.github.sadikovi.riff.tree.expression.EqualTo;
@@ -73,6 +78,10 @@ public class FilterApi {
       return new UTF8StringExpression(UTF8String.fromString((String) obj));
     } else if (obj instanceof UTF8String) {
       return new UTF8StringExpression((UTF8String) obj);
+    } else if (obj instanceof Date) {
+      return new DateExpression((Date) obj);
+    } else if (obj instanceof Timestamp) {
+      return new TimestampExpression((Timestamp) obj);
     } else {
       throw new UnsupportedOperationException("Object " + obj + " of " + obj.getClass());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/DateExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/DateExpression.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree.expression;
+
+import java.sql.Date;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+
+import com.github.sadikovi.riff.tree.TypedExpression;
+
+/**
+ * [[DateExpression]] to represent java.sql.Date as integer in Catalyst.
+ */
+public class DateExpression extends IntegerExpression {
+  public DateExpression(Date value) {
+    super(DateTimeUtils.fromJavaDate(value));
+  }
+
+  /** Internal constructor to convert directly to IntegerExpression */
+  protected DateExpression(int value) {
+    super(value);
+  }
+
+  @Override
+  public DataType dataType() {
+    return DataTypes.DateType;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof DateExpression)) return false;
+    DateExpression expr = (DateExpression) obj;
+    return expr.value == value;
+  }
+
+  @Override
+  public TypedExpression copy() {
+    return new DateExpression(value);
+  }
+
+  @Override
+  public String prettyString() {
+    return "DATE(" + value + ")";
+  }
+}

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/TimestampExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/TimestampExpression.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree.expression;
+
+import java.sql.Timestamp;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+
+import com.github.sadikovi.riff.tree.TypedExpression;
+
+/**
+ * [[TimestampExpression]] to represent java.sql.Timestamp as long in Catalyst.
+ */
+public class TimestampExpression extends LongExpression {
+  public TimestampExpression(Timestamp value) {
+    super(DateTimeUtils.fromJavaTimestamp(value));
+  }
+
+  /** Internal constructor to convert directly to LongExpression */
+  protected TimestampExpression(long value) {
+    super(value);
+  }
+
+  @Override
+  public DataType dataType() {
+    return DataTypes.TimestampType;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof TimestampExpression)) return false;
+    TimestampExpression expr = (TimestampExpression) obj;
+    return expr.value == value;
+  }
+
+  @Override
+  public TypedExpression copy() {
+    return new TimestampExpression(value);
+  }
+
+  @Override
+  public String prettyString() {
+    return "TIMESTAMP(" + value + ")";
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
@@ -72,6 +72,23 @@ class ColumnFilterSuite extends UnitTestSuite {
     filter3.mightContain(row.getUTF8String(2)) should be (false)
     filter3.update(row, 2)
     filter3.mightContain(row.getUTF8String(2)) should be (true)
+
+    // DateType is backed by integer type in Spark SQL
+    val filter4 = ColumnFilter.sqlTypeToColumnFilter(DateType, 64)
+    filter4.mightContain(row.getInt(0)) should be (false)
+    filter4.update(row, 0)
+    filter4.mightContain(row.getInt(0)) should be (true)
+
+    // TimestampType is backed by long type in Spark SQL
+    val filter5 = ColumnFilter.sqlTypeToColumnFilter(TimestampType, 64)
+    filter5.mightContain(row.getLong(1)) should be (false)
+    filter5.update(row, 1)
+    filter5.mightContain(row.getLong(1)) should be (true)
+  }
+
+  test("select bloom filters for date type and timestamp type") {
+    val filter1 = ColumnFilter.sqlTypeToColumnFilter(DateType, 64)
+    val filter2 = ColumnFilter.sqlTypeToColumnFilter(TimestampType, 64)
   }
 
   test("bloom filter write/read") {

--- a/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
@@ -34,6 +34,8 @@ class ConvertersSuite extends UnitTestSuite {
   test("converter for sql type") {
     Converters.sqlTypeToConverter(IntegerType) should be (new IndexedRowIntConverter())
     Converters.sqlTypeToConverter(LongType) should be (new IndexedRowLongConverter())
+    Converters.sqlTypeToConverter(DateType) should be (new IndexedRowIntConverter())
+    Converters.sqlTypeToConverter(TimestampType) should be (new IndexedRowLongConverter())
     Converters.sqlTypeToConverter(StringType) should be (new IndexedRowUTF8Converter())
   }
 

--- a/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
@@ -22,6 +22,7 @@
 
 package com.github.sadikovi.riff
 
+import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.github.sadikovi.testutil.UnitTestSuite
@@ -71,5 +72,11 @@ class ProjectionRowSuite extends UnitTestSuite {
     row.getInt(0) should be (1)
     row.getLong(1) should be (2L)
     row.getUTF8String(2) should be (UTF8String.fromString("abc"))
+
+    row.get(0, IntegerType) should be (1)
+    row.get(1, LongType) should be (2L)
+    row.get(2, StringType) should be (UTF8String.fromString("abc"))
+    row.get(0, DateType) should be (1)
+    row.get(1, TimestampType) should be (2L)
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
@@ -52,18 +52,28 @@ class StatisticsSuite extends UnitTestSuite {
     intStats.id should be (IntStatistics.ID)
     intStats.hasNulls should be (false)
 
+    val dateStats = Statistics.sqlTypeToStatistics(DateType)
+    dateStats.getClass should be (classOf[IntStatistics])
+    dateStats.id should be (IntStatistics.ID)
+    dateStats.hasNulls should be (false)
+
     val longStats = Statistics.sqlTypeToStatistics(LongType)
     longStats.getClass should be (classOf[LongStatistics])
     longStats.id should be (LongStatistics.ID)
     longStats.hasNulls should be (false)
+
+    val timestampStats = Statistics.sqlTypeToStatistics(TimestampType)
+    timestampStats.getClass should be (classOf[LongStatistics])
+    timestampStats.id should be (LongStatistics.ID)
+    timestampStats.hasNulls should be (false)
 
     val utfStats = Statistics.sqlTypeToStatistics(StringType)
     utfStats.getClass should be (classOf[UTF8StringStatistics])
     utfStats.id should be (UTF8StringStatistics.ID)
     utfStats.hasNulls should be (false)
 
-    // date type is not supported
-    val noopStats = Statistics.sqlTypeToStatistics(DateType)
+    // null type is not supported
+    val noopStats = Statistics.sqlTypeToStatistics(NullType)
     noopStats.getClass should be (classOf[NoopStatistics])
     noopStats.id should be (NoopStatistics.ID)
     noopStats.hasNulls should be (false)

--- a/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
@@ -53,6 +53,8 @@ class TypeDescriptionSuite extends UnitTestSuite {
     TypeDescription.isSupportedDataType(IntegerType) should be (true)
     TypeDescription.isSupportedDataType(LongType) should be (true)
     TypeDescription.isSupportedDataType(StringType) should be (true)
+    TypeDescription.isSupportedDataType(DateType) should be (true)
+    TypeDescription.isSupportedDataType(TimestampType) should be (true)
   }
 
   test("unsupported types") {
@@ -61,8 +63,6 @@ class TypeDescriptionSuite extends UnitTestSuite {
     TypeDescription.isSupportedDataType(ByteType) should be (false)
     TypeDescription.isSupportedDataType(DoubleType) should be (false)
     TypeDescription.isSupportedDataType(NullType) should be (false)
-    TypeDescription.isSupportedDataType(DateType) should be (false)
-    TypeDescription.isSupportedDataType(TimestampType) should be (false)
   }
 
   test("assert schema - unsupported type") {

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
@@ -22,6 +22,7 @@
 
 package com.github.sadikovi.riff.tree
 
+import java.sql.{Date, Timestamp}
 import java.util.NoSuchElementException
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -71,6 +72,14 @@ class FilterSuite extends UnitTestSuite {
     expr = FilterApi.objToExpression("3")
     expr.isInstanceOf[UTF8StringExpression] should be (true)
     expr.prettyString should be ("'3'")
+
+    expr = FilterApi.objToExpression(new Date(1234567890L))
+    expr.isInstanceOf[DateExpression] should be (true)
+    expr.prettyString should be ("DATE(14)")
+
+    expr = FilterApi.objToExpression(new Timestamp(1234567890L))
+    expr.isInstanceOf[TimestampExpression] should be (true)
+    expr.prettyString should be ("TIMESTAMP(1234567890000)")
   }
 
   test("FilterApi - objToExpression, exceptions") {

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
@@ -22,8 +22,10 @@
 
 package com.github.sadikovi.riff.tree.expression
 
+import java.sql.{Date, Timestamp}
+
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.types.{IntegerType, LongType, StringType}
+import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import com.github.sadikovi.riff.ColumnFilter
@@ -229,5 +231,49 @@ class ExpressionSuite extends UnitTestSuite {
     filter.update(InternalRow(UTF8String.fromString("ttt")), 0)
     new UTF8StringExpression(UTF8String.fromString("ttt")).containsExpr(filter) should be (true)
     new UTF8StringExpression(UTF8String.fromString("zzz")).containsExpr(filter) should be (false)
+  }
+
+  test("DateExpression - check expression") {
+    // inherits comparison methods from IntegerExpression
+    val time = 1234567890L
+    val expr = new DateExpression(new Date(time))
+    expr.dataType should be (DateType)
+    expr.prettyString should be ("DATE(14)")
+    // equals
+    expr.equals(null) should be (false)
+    expr.equals(expr) should be (true)
+    expr.equals(new DateExpression(new Date(time))) should be (true)
+    expr.equals(new DateExpression(new Date(System.currentTimeMillis))) should be (false)
+    // hashCode
+    expr.hashCode should be (14)
+    // compareTo
+    expr.compareTo(expr) should be (0)
+    expr.compareTo(new DateExpression(new Date(1L))) should be (1)
+    expr.compareTo(new DateExpression(new Date(System.currentTimeMillis))) should be (-1)
+    // copy
+    assert(expr.copy().isInstanceOf[DateExpression])
+    expr.copy() should be (expr)
+  }
+
+  test("TimestampExpression - check expression") {
+    // inherits comparison methods from LongExpression
+    val time = 1234567890L
+    val expr = new TimestampExpression(new Timestamp(time))
+    expr.dataType should be (TimestampType)
+    expr.prettyString should be (s"TIMESTAMP(1234567890000)")
+    // equals
+    expr.equals(null) should be (false)
+    expr.equals(expr) should be (true)
+    expr.equals(new TimestampExpression(new Timestamp(time))) should be (true)
+    expr.equals(new TimestampExpression(new Timestamp(System.currentTimeMillis))) should be (false)
+    // hashCode
+    expr.hashCode should be (1912276303)
+    // compareTo
+    expr.compareTo(expr) should be (0)
+    expr.compareTo(new TimestampExpression(new Timestamp(1L))) should be (1)
+    expr.compareTo(new TimestampExpression(new Timestamp(System.currentTimeMillis))) should be (-1)
+    // copy
+    assert(expr.copy().isInstanceOf[TimestampExpression])
+    expr.copy() should be (expr)
   }
 }


### PR DESCRIPTION
This PR adds support for `DateType` and `TimestampType` Spark SQL types. Both types essentially inherit all functionality of integer and long expressions.