### PR TITLE
Add BooleanType

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ These options that you can specify when writing DataFrame by calling `df.write.o
 - `StringType`
 - `DateType`
 - `TimestampType`
+- `BooleanType`
 
 ## Example
 Usage is very similar to other datasources for Spark, e.g. Parquet, ORC, JSON, etc. Riff allows to

--- a/format/src/main/java/com/github/sadikovi/riff/Converters.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Converters.java
@@ -25,6 +25,7 @@ package com.github.sadikovi.riff;
 import java.io.IOException;
 
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
@@ -54,6 +55,8 @@ public class Converters {
       return new IndexedRowIntConverter();
     } else if (dataType instanceof TimestampType) {
       return new IndexedRowLongConverter();
+    } else if (dataType instanceof BooleanType) {
+      return new IndexedRowBooleanConverter();
     } else {
       throw new RuntimeException("No converter registered for type " + dataType);
     }
@@ -131,6 +134,24 @@ public class Converters {
     public int byteOffset() {
       // metadata size (offset + length)
       return 8;
+    }
+  }
+
+  public static class IndexedRowBooleanConverter extends IndexedRowValueConverter {
+    @Override
+    public void writeDirect(
+        InternalRow row,
+        int ordinal,
+        OutputBuffer fixedBuffer,
+        int fixedOffset,
+        OutputBuffer variableBuffer) throws IOException {
+      fixedBuffer.writeBoolean(row.getBoolean(ordinal));
+    }
+
+    @Override
+    public int byteOffset() {
+      // boolean is written into single byte
+      return 1;
     }
   }
 }

--- a/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
@@ -25,6 +25,7 @@ package com.github.sadikovi.riff;
 import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
@@ -134,6 +135,16 @@ public class ProjectionRow extends GenericInternalRow {
     return getLongValue(ordinal).longValue();
   }
 
+  /** Method to cast and retrieve boolean value */
+  private Boolean getBooleanValue(int ordinal) {
+    return (Boolean) values[ordinal];
+  }
+
+  @Override
+  public boolean getBoolean(int ordinal) {
+    return getBooleanValue(ordinal).booleanValue();
+  }
+
   @Override
   public UTF8String getUTF8String(int ordinal) {
     return (UTF8String) values[ordinal];
@@ -153,6 +164,8 @@ public class ProjectionRow extends GenericInternalRow {
       return getIntegerValue(ordinal);
     } else if (dataType instanceof TimestampType) {
       return getLongValue(ordinal);
+    } else if (dataType instanceof BooleanType) {
+      return getBooleanValue(ordinal);
     } else {
       throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/Statistics.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Statistics.java
@@ -552,6 +552,7 @@ public abstract class Statistics extends GenericInternalRow {
 
     @Override
     public boolean getBoolean(int ordinal) {
+      if (!hasValues) throw new IllegalStateException("Boolean statistics are not set");
       if (ordinal == ORD_MIN) return min;
       if (ordinal == ORD_MAX) return max;
       throw new UnsupportedOperationException("Invalid ordinal " + ordinal);

--- a/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
+++ b/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 
+import org.apache.spark.sql.types.BooleanType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
@@ -160,7 +161,8 @@ public class TypeDescription implements Externalizable {
       (dataType instanceof LongType) ||
       (dataType instanceof StringType) ||
       (dataType instanceof DateType) ||
-      (dataType instanceof TimestampType);
+      (dataType instanceof TimestampType) ||
+      (dataType instanceof BooleanType);
   }
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
@@ -27,6 +27,7 @@ import java.sql.Timestamp;
 
 import org.apache.spark.unsafe.types.UTF8String;
 
+import com.github.sadikovi.riff.tree.expression.BooleanExpression;
 import com.github.sadikovi.riff.tree.expression.DateExpression;
 import com.github.sadikovi.riff.tree.expression.IntegerExpression;
 import com.github.sadikovi.riff.tree.expression.LongExpression;
@@ -82,6 +83,8 @@ public class FilterApi {
       return new DateExpression((Date) obj);
     } else if (obj instanceof Timestamp) {
       return new TimestampExpression((Timestamp) obj);
+    } else if (obj instanceof Boolean) {
+      return new BooleanExpression((Boolean) obj);
     } else {
       throw new UnsupportedOperationException("Object " + obj + " of " + obj.getClass());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/BooleanExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/BooleanExpression.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree.expression;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+
+import com.github.sadikovi.riff.ColumnFilter;
+import com.github.sadikovi.riff.tree.TypedExpression;
+
+/**
+ * [[BooleanExpression]] to hold boolean value that used for comparison for all typed bound
+ * references.
+ */
+public class BooleanExpression implements TypedExpression<BooleanExpression> {
+  // value is accessible to equality and comparison methods
+  protected final boolean value;
+
+  public BooleanExpression(boolean value) {
+    this.value = value;
+  }
+
+  @Override
+  public DataType dataType() {
+    return DataTypes.BooleanType;
+  }
+
+  @Override
+  public boolean eqExpr(InternalRow row, int ordinal) {
+    return row.getBoolean(ordinal) == value;
+  }
+
+  @Override
+  public boolean gtExpr(InternalRow row, int ordinal) {
+    // value is greater than expression only if row ordinal is true and expression is false
+    return row.getBoolean(ordinal) && !value;
+  }
+
+  @Override
+  public boolean ltExpr(InternalRow row, int ordinal) {
+    // inverse of previous expression, row ordinal is false and expression is true
+    return !row.getBoolean(ordinal) && value;
+  }
+
+  @Override
+  public boolean geExpr(InternalRow row, int ordinal) {
+    return eqExpr(row, ordinal) || gtExpr(row, ordinal);
+  }
+
+  @Override
+  public boolean leExpr(InternalRow row, int ordinal) {
+    return eqExpr(row, ordinal) || ltExpr(row, ordinal);
+  }
+
+  @Override
+  public boolean containsExpr(ColumnFilter filter) {
+    return filter.mightContain(value);
+  }
+
+  @Override
+  public int compareTo(BooleanExpression obj) {
+    if (!value && obj.value) {
+      return -1;
+    } else if (value && !obj.value) {
+      return 1;
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof BooleanExpression)) return false;
+    BooleanExpression expr = (BooleanExpression) obj;
+    return expr.value == value;
+  }
+
+  @Override
+  public int hashCode() {
+    return value ? 1 : 0;
+  }
+
+  @Override
+  public TypedExpression copy() {
+    return new BooleanExpression(value);
+  }
+
+  @Override
+  public String prettyString() {
+    return "" + value;
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ColumnFilterSuite.scala
@@ -102,6 +102,32 @@ class ColumnFilterSuite extends UnitTestSuite {
     filter2.mightContain(row.getInt(0)) should be (true)
   }
 
+  test("boolean filter - update/mightContain") {
+    val filter = ColumnFilter.sqlTypeToColumnFilter(BooleanType, 0)
+    filter.mightContain(false) should be (false)
+    filter.mightContain(true) should be (false)
+    // update true values only
+    filter.update(InternalRow(true), 0)
+    filter.mightContain(false) should be (false)
+    filter.mightContain(true) should be (true)
+    // filter should contain both values
+    filter.update(InternalRow(false), 0)
+    filter.mightContain(false) should be (true)
+    filter.mightContain(true) should be (true)
+  }
+
+  test("boolean filter write/read") {
+    val row = InternalRow(true)
+    val out = new OutputBuffer()
+    val filter1 = ColumnFilter.sqlTypeToColumnFilter(BooleanType, 0)
+    filter1.update(row, 0)
+    filter1.writeExternal(out)
+    val filter2 = ColumnFilter.readExternal(ByteBuffer.wrap(out.array))
+    filter2 should be (filter1)
+    filter2.mightContain(true) should be (true)
+    filter2.mightContain(false) should be (false)
+  }
+
   test("select noop filter for unsupported data type") {
     val filter = ColumnFilter.sqlTypeToColumnFilter(NullType, 10)
     filter should be (ColumnFilter.noopFilter)

--- a/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
@@ -95,4 +95,18 @@ class ConvertersSuite extends UnitTestSuite {
       98, 99, 100, 101
     ))
   }
+
+  test("indexed row boolean converter") {
+    val row = InternalRow(123, true, false)
+    val fixedBuffer = new OutputBuffer()
+    val variableBuffer = new OutputBuffer()
+
+    val cnv = new IndexedRowBooleanConverter()
+    // 8 bytes for long value
+    cnv.byteOffset() should be (1)
+    cnv.writeDirect(row, 1, fixedBuffer, 4, variableBuffer)
+    cnv.writeDirect(row, 2, fixedBuffer, 4, variableBuffer)
+    fixedBuffer.array() should be (Array[Byte](1, 0))
+    assert(variableBuffer.array().isEmpty)
+  }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
@@ -102,7 +102,6 @@ class ConvertersSuite extends UnitTestSuite {
     val variableBuffer = new OutputBuffer()
 
     val cnv = new IndexedRowBooleanConverter()
-    // 8 bytes for long value
     cnv.byteOffset() should be (1)
     cnv.writeDirect(row, 1, fixedBuffer, 4, variableBuffer)
     cnv.writeDirect(row, 2, fixedBuffer, 4, variableBuffer)

--- a/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
@@ -64,10 +64,12 @@ class ProjectionRowSuite extends UnitTestSuite {
   }
 
   test("get values") {
-    val row = new ProjectionRow(3)
+    val row = new ProjectionRow(5)
     row.update(0, 1)
     row.update(1, 2L)
     row.update(2, UTF8String.fromString("abc"))
+    row.update(3, true)
+    row.update(4, false)
 
     row.getInt(0) should be (1)
     row.getLong(1) should be (2L)
@@ -78,5 +80,7 @@ class ProjectionRowSuite extends UnitTestSuite {
     row.get(2, StringType) should be (UTF8String.fromString("abc"))
     row.get(0, DateType) should be (1)
     row.get(1, TimestampType) should be (2L)
+    assert(row.get(3, BooleanType) === true)
+    assert(row.get(4, BooleanType) === false)
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
@@ -152,8 +152,8 @@ class StatisticsSuite extends UnitTestSuite {
     val booleanStats = Statistics.sqlTypeToStatistics(BooleanType)
     booleanStats.isNullAt(Statistics.ORD_MIN) should be (true)
     booleanStats.isNullAt(Statistics.ORD_MAX) should be (true)
-    booleanStats.getBoolean(Statistics.ORD_MIN) should be (true)
-    booleanStats.getBoolean(Statistics.ORD_MAX) should be (false)
+    intercept[IllegalStateException] { booleanStats.getBoolean(Statistics.ORD_MIN) }
+    intercept[IllegalStateException] { booleanStats.getBoolean(Statistics.ORD_MAX) }
 
     booleanStats.update(InternalRow(false), 0)
     booleanStats.isNullAt(Statistics.ORD_MIN) should be (false)

--- a/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/StatisticsSuite.scala
@@ -72,6 +72,11 @@ class StatisticsSuite extends UnitTestSuite {
     utfStats.id should be (UTF8StringStatistics.ID)
     utfStats.hasNulls should be (false)
 
+    val booleanStats = Statistics.sqlTypeToStatistics(BooleanType)
+    booleanStats.getClass should be (classOf[BooleanStatistics])
+    booleanStats.id should be (BooleanStatistics.ID)
+    booleanStats.hasNulls should be (false)
+
     // null type is not supported
     val noopStats = Statistics.sqlTypeToStatistics(NullType)
     noopStats.getClass should be (classOf[NoopStatistics])
@@ -141,6 +146,26 @@ class StatisticsSuite extends UnitTestSuite {
     utfStats.isNullAt(Statistics.ORD_MAX) should be (false)
     utfStats.getUTF8String(Statistics.ORD_MIN) should be (UTF8String.fromString("123"))
     utfStats.getUTF8String(Statistics.ORD_MAX) should be (UTF8String.fromString("abc"))
+  }
+
+  test("update state for boolean stats") {
+    val booleanStats = Statistics.sqlTypeToStatistics(BooleanType)
+    booleanStats.isNullAt(Statistics.ORD_MIN) should be (true)
+    booleanStats.isNullAt(Statistics.ORD_MAX) should be (true)
+    booleanStats.getBoolean(Statistics.ORD_MIN) should be (true)
+    booleanStats.getBoolean(Statistics.ORD_MAX) should be (false)
+
+    booleanStats.update(InternalRow(false), 0)
+    booleanStats.isNullAt(Statistics.ORD_MIN) should be (false)
+    booleanStats.isNullAt(Statistics.ORD_MAX) should be (false)
+    booleanStats.getBoolean(Statistics.ORD_MIN) should be (false)
+    booleanStats.getBoolean(Statistics.ORD_MAX) should be (false)
+
+    booleanStats.update(InternalRow(true), 0)
+    booleanStats.isNullAt(Statistics.ORD_MIN) should be (false)
+    booleanStats.isNullAt(Statistics.ORD_MAX) should be (false)
+    booleanStats.getBoolean(Statistics.ORD_MIN) should be (false)
+    booleanStats.getBoolean(Statistics.ORD_MAX) should be (true)
   }
 
   test("ensure copy when updating state for utf8 stats") {
@@ -234,6 +259,26 @@ class StatisticsSuite extends UnitTestSuite {
     Statistics.readExternal(in) should be (utfStats)
   }
 
+  test("write/read for empty boolean stats") {
+    val buf = new OutputBuffer()
+    val booleanStats = Statistics.sqlTypeToStatistics(BooleanType)
+    booleanStats.writeExternal(buf)
+    val in = ByteBuffer.wrap(buf.array())
+    Statistics.readExternal(in) should be (booleanStats)
+  }
+
+  test("write/read for non-empty boolean stats") {
+    val buf = new OutputBuffer()
+    val booleanStats = Statistics.sqlTypeToStatistics(BooleanType)
+    booleanStats.update(InternalRow(true), 0)
+    booleanStats.update(InternalRow(null), 0)
+    booleanStats.update(InternalRow(false), 0)
+    booleanStats.writeExternal(buf)
+
+    val in = ByteBuffer.wrap(buf.array())
+    Statistics.readExternal(in) should be (booleanStats)
+  }
+
   test("merge int stats") {
     val s1 = new IntStatistics()
     s1.update(InternalRow(100), 0)
@@ -291,6 +336,46 @@ class StatisticsSuite extends UnitTestSuite {
     s1.merge(s2)
     s1.getUTF8String(Statistics.ORD_MIN) should be (UTF8String.fromString("bbb"))
     s1.getUTF8String(Statistics.ORD_MAX) should be (UTF8String.fromString("ddd"))
+    s1.hasNulls should be (false)
+  }
+
+  test("merge boolean stats 1") {
+    val s1 = new BooleanStatistics()
+    s1.update(InternalRow(false), 0)
+    val s2 = new BooleanStatistics()
+    s2.update(InternalRow(true), 0)
+    s2.update(InternalRow(null), 0)
+
+    s1.merge(s2)
+    assert(s1 != s2)
+    s1.isNullAt(Statistics.ORD_MIN) should be (false)
+    s1.isNullAt(Statistics.ORD_MAX) should be (false)
+    s1.getBoolean(Statistics.ORD_MIN) should be (false)
+    s1.getBoolean(Statistics.ORD_MAX) should be (true)
+    s1.hasNulls should be (true)
+  }
+
+  test("merge boolean stats 2") {
+    val s1 = new BooleanStatistics()
+    val s2 = new BooleanStatistics()
+    s2.update(InternalRow(true), 0)
+    s2.update(InternalRow(null), 0)
+
+    s1.merge(s2)
+    s1.isNullAt(Statistics.ORD_MIN) should be (false)
+    s1.isNullAt(Statistics.ORD_MAX) should be (false)
+    s1.getBoolean(Statistics.ORD_MIN) should be (true)
+    s1.getBoolean(Statistics.ORD_MAX) should be (true)
+    s1.hasNulls should be (true)
+  }
+
+  test("merge boolean stats 3") {
+    val s1 = new BooleanStatistics()
+    val s2 = new BooleanStatistics()
+
+    s1.merge(s2)
+    s1.isNullAt(Statistics.ORD_MIN) should be (true)
+    s1.isNullAt(Statistics.ORD_MAX) should be (true)
     s1.hasNulls should be (false)
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
@@ -55,10 +55,10 @@ class TypeDescriptionSuite extends UnitTestSuite {
     TypeDescription.isSupportedDataType(StringType) should be (true)
     TypeDescription.isSupportedDataType(DateType) should be (true)
     TypeDescription.isSupportedDataType(TimestampType) should be (true)
+    TypeDescription.isSupportedDataType(BooleanType) should be (true)
   }
 
   test("unsupported types") {
-    TypeDescription.isSupportedDataType(BooleanType) should be (false)
     TypeDescription.isSupportedDataType(ShortType) should be (false)
     TypeDescription.isSupportedDataType(ByteType) should be (false)
     TypeDescription.isSupportedDataType(DoubleType) should be (false)

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
@@ -80,13 +80,17 @@ class FilterSuite extends UnitTestSuite {
     expr = FilterApi.objToExpression(new Timestamp(1234567890L))
     expr.isInstanceOf[TimestampExpression] should be (true)
     expr.prettyString should be ("TIMESTAMP(1234567890000)")
+
+    expr = FilterApi.objToExpression(true)
+    expr.isInstanceOf[BooleanExpression] should be (true)
+    expr.prettyString should be ("true")
   }
 
   test("FilterApi - objToExpression, exceptions") {
     val err1 = intercept[NullPointerException] { FilterApi.objToExpression(null) }
     err1.getMessage should be ("Cannot convert null into typed expression")
-    val err2 = intercept[UnsupportedOperationException] { FilterApi.objToExpression(true) }
-    err2.getMessage should be ("Object true of class java.lang.Boolean")
+    val err2 = intercept[UnsupportedOperationException] { FilterApi.objToExpression(Map.empty) }
+    err2.getMessage should be ("Object Map() of class scala.collection.immutable.Map$EmptyMap$")
   }
 
   test("Trivial predicate") {

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
@@ -260,7 +260,7 @@ class ExpressionSuite extends UnitTestSuite {
     val time = 1234567890L
     val expr = new TimestampExpression(new Timestamp(time))
     expr.dataType should be (TimestampType)
-    expr.prettyString should be (s"TIMESTAMP(1234567890000)")
+    expr.prettyString should be ("TIMESTAMP(1234567890000)")
     // equals
     expr.equals(null) should be (false)
     expr.equals(expr) should be (true)
@@ -275,5 +275,47 @@ class ExpressionSuite extends UnitTestSuite {
     // copy
     assert(expr.copy().isInstanceOf[TimestampExpression])
     expr.copy() should be (expr)
+  }
+
+  test("BooleanExpression - misc methods") {
+    val expr = new BooleanExpression(true)
+    expr.dataType should be (BooleanType)
+    expr.prettyString should be ("true")
+    // equals
+    expr.equals(null) should be (false)
+    expr.equals(expr) should be (true)
+    expr.equals(new BooleanExpression(true)) should be (true)
+    expr.equals(new BooleanExpression(false)) should be (false)
+    // hashCode
+    expr.hashCode should be (1)
+    // compareTo
+    expr.compareTo(expr) should be (0)
+    expr.compareTo(new BooleanExpression(false)) should be (1)
+    new BooleanExpression(false).compareTo(expr) should be (-1)
+    // copy
+    assert(expr.copy().isInstanceOf[BooleanExpression])
+    expr.copy() should be (expr)
+  }
+
+  test("BooleanExpression - check expression") {
+    val expr = new BooleanExpression(true)
+    // equality
+    expr.eqExpr(InternalRow(true), 0) should be (true)
+    expr.eqExpr(InternalRow(false), 0) should be (false)
+    // greater than
+    expr.gtExpr(InternalRow(true), 0) should be (false)
+    expr.gtExpr(InternalRow(false), 0) should be (false)
+    new BooleanExpression(false).gtExpr(InternalRow(true), 0) should be (true)
+    // less than
+    expr.ltExpr(InternalRow(true), 0) should be (false)
+    expr.ltExpr(InternalRow(false), 0) should be (true)
+    // greater than or equal
+    expr.geExpr(InternalRow(true), 0) should be (true)
+    expr.geExpr(InternalRow(false), 0) should be (false)
+    new BooleanExpression(false).geExpr(InternalRow(true), 0) should be (true)
+    // less than or equal
+    expr.leExpr(InternalRow(true), 0) should be (true)
+    expr.leExpr(InternalRow(false), 0) should be (true)
+    new BooleanExpression(false).leExpr(InternalRow(true), 0) should be (false)
   }
 }

--- a/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
@@ -264,6 +264,13 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
     checkDataType(TimestampType, seq, _.filter(col("col") === new Timestamp(20000L)))
   }
 
+  test("write/read dataframe, BooleanType") {
+    val seq = Row(true) :: Row(false) :: Row(null) :: Nil
+    checkDataType(BooleanType, seq)
+    checkDataType(BooleanType, seq, _.filter("col is null"))
+    checkDataType(BooleanType, seq, _.filter(col("col") === true))
+  }
+
   //////////////////////////////////////////////////////////////
   // == Write/read checks for compression codecs
   //////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds Spark SQL `BooleanType` support with boolean statistics and column filter.