### PR TITLE
Fix writing last stripe in file

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -207,7 +207,7 @@ public class FileWriter {
   public void prepareWrite() throws IOException {
     if (writeFinished) throw new IOException("Writer reuse");
     if (writePrepared) return;
-    LOG.debug("Prepare file's type description {}", td);
+    LOG.debug("Prepare file writer {}", this);
     stripeId = 0;
     currentOffset = 0L;
     stripes = new ArrayList<StripeInformation>();
@@ -280,7 +280,7 @@ public class FileWriter {
       // flush the last stripe into output stream
       stripeStream.flush();
       StripeInformation stripeInfo =
-        new StripeInformation(stripe, currentOffset, stripeStats);
+        new StripeInformation(stripe, currentOffset, stripeStats, stripeFilters);
       stripe.flush(temporaryStream);
       LOG.debug("Finished writing stripe {}, records={}", stripeInfo,
         numRowsInStripe - stripeCurrentRecords);


### PR DESCRIPTION
When writing stripes, we would forget writing column filters into last stripe. This is fixed in the patch. Also updated log to print all file writer string, not just type description, since file writer is defined at that point.