### PR TITLE
Add ShortType and ByteType support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ These options that you can specify when writing DataFrame by calling `df.write.o
 - `DateType`
 - `TimestampType`
 - `BooleanType`
+- `ShortType`
+- `ByteType`
 
 ## Example
 Usage is very similar to other datasources for Spark, e.g. Parquet, ORC, JSON, etc. Riff allows to

--- a/format/src/main/java/com/github/sadikovi/riff/Converters.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Converters.java
@@ -26,10 +26,12 @@ import java.io.IOException;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.TimestampType;
 
@@ -57,6 +59,10 @@ public class Converters {
       return new IndexedRowLongConverter();
     } else if (dataType instanceof BooleanType) {
       return new IndexedRowBooleanConverter();
+    } else if (dataType instanceof ShortType) {
+      return new IndexedRowShortConverter();
+    } else if (dataType instanceof ByteType) {
+      return new IndexedRowByteConverter();
     } else {
       throw new RuntimeException("No converter registered for type " + dataType);
     }
@@ -151,6 +157,40 @@ public class Converters {
     @Override
     public int byteOffset() {
       // boolean is written into single byte
+      return 1;
+    }
+  }
+
+  public static class IndexedRowShortConverter extends IndexedRowValueConverter {
+    @Override
+    public void writeDirect(
+        InternalRow row,
+        int ordinal,
+        OutputBuffer fixedBuffer,
+        int fixedOffset,
+        OutputBuffer variableBuffer) throws IOException {
+      fixedBuffer.writeShort(row.getShort(ordinal));
+    }
+
+    @Override
+    public int byteOffset() {
+      return 2;
+    }
+  }
+
+  public static class IndexedRowByteConverter extends IndexedRowValueConverter {
+    @Override
+    public void writeDirect(
+        InternalRow row,
+        int ordinal,
+        OutputBuffer fixedBuffer,
+        int fixedOffset,
+        OutputBuffer variableBuffer) throws IOException {
+      fixedBuffer.writeByte(row.getByte(ordinal));
+    }
+
+    @Override
+    public int byteOffset() {
       return 1;
     }
   }

--- a/format/src/main/java/com/github/sadikovi/riff/IndexedRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/IndexedRow.java
@@ -27,11 +27,13 @@ import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.NullType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -229,6 +231,24 @@ final class IndexedRow extends GenericInternalRow {
   }
 
   @Override
+  public short getShort(int ordinal) {
+    if (isIndexed(ordinal)) {
+      return this.indexBuffer.getShort(this.offsets[ordinal]);
+    } else {
+      return this.dataBuffer.getShort(this.offsets[ordinal]);
+    }
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    if (isIndexed(ordinal)) {
+      return this.indexBuffer.get(this.offsets[ordinal]);
+    } else {
+      return this.dataBuffer.get(this.offsets[ordinal]);
+    }
+  }
+
+  @Override
   public Object get(int ordinal, DataType dataType) {
     if (isNullAt(ordinal) || dataType instanceof NullType) {
       return null;
@@ -244,6 +264,10 @@ final class IndexedRow extends GenericInternalRow {
       return getLong(ordinal);
     } else if (dataType instanceof BooleanType) {
       return getBoolean(ordinal);
+    } else if (dataType instanceof ShortType) {
+      return getShort(ordinal);
+    } else if (dataType instanceof ByteType) {
+      return getByte(ordinal);
     } else {
       throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/ProjectionRow.java
@@ -26,11 +26,13 @@ import java.util.Arrays;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.NullType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -150,6 +152,26 @@ public class ProjectionRow extends GenericInternalRow {
     return (UTF8String) values[ordinal];
   }
 
+  /** Method to cast and retrieve short value */
+  private Short getShortValue(int ordinal) {
+    return (Short) values[ordinal];
+  }
+
+  @Override
+  public short getShort(int ordinal) {
+    return getShortValue(ordinal).shortValue();
+  }
+
+  /** Method to cast and retrieve short value */
+  private Byte getByteValue(int ordinal) {
+    return (Byte) values[ordinal];
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    return getByteValue(ordinal).byteValue();
+  }
+
   @Override
   public Object get(int ordinal, DataType dataType) {
     if (isNullAt(ordinal) || dataType instanceof NullType) {
@@ -166,6 +188,10 @@ public class ProjectionRow extends GenericInternalRow {
       return getLongValue(ordinal);
     } else if (dataType instanceof BooleanType) {
       return getBooleanValue(ordinal);
+    } else if (dataType instanceof ShortType) {
+      return getShortValue(ordinal);
+    } else if (dataType instanceof ByteType) {
+      return getByteValue(ordinal);
     } else {
       throw new UnsupportedOperationException("Unsupported data type " + dataType.simpleString());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
+++ b/format/src/main/java/com/github/sadikovi/riff/TypeDescription.java
@@ -36,10 +36,12 @@ import java.util.HashSet;
 import java.util.NoSuchElementException;
 
 import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -162,7 +164,9 @@ public class TypeDescription implements Externalizable {
       (dataType instanceof StringType) ||
       (dataType instanceof DateType) ||
       (dataType instanceof TimestampType) ||
-      (dataType instanceof BooleanType);
+      (dataType instanceof BooleanType) ||
+      (dataType instanceof ShortType) ||
+      (dataType instanceof ByteType);
   }
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/FilterApi.java
@@ -28,9 +28,11 @@ import java.sql.Timestamp;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import com.github.sadikovi.riff.tree.expression.BooleanExpression;
+import com.github.sadikovi.riff.tree.expression.ByteExpression;
 import com.github.sadikovi.riff.tree.expression.DateExpression;
 import com.github.sadikovi.riff.tree.expression.IntegerExpression;
 import com.github.sadikovi.riff.tree.expression.LongExpression;
+import com.github.sadikovi.riff.tree.expression.ShortExpression;
 import com.github.sadikovi.riff.tree.expression.TimestampExpression;
 import com.github.sadikovi.riff.tree.expression.UTF8StringExpression;
 
@@ -85,6 +87,10 @@ public class FilterApi {
       return new TimestampExpression((Timestamp) obj);
     } else if (obj instanceof Boolean) {
       return new BooleanExpression((Boolean) obj);
+    } else if (obj instanceof Short) {
+      return new ShortExpression((Short) obj);
+    } else if (obj instanceof Byte) {
+      return new ByteExpression((Byte) obj);
     } else {
       throw new UnsupportedOperationException("Object " + obj + " of " + obj.getClass());
     }

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/ByteExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/ByteExpression.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree.expression;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+
+import com.github.sadikovi.riff.ColumnFilter;
+import com.github.sadikovi.riff.tree.TypedExpression;
+
+/**
+ * [[ByteExpression]] to hold byte value that used for comparison for all typed bound references.
+ */
+public class ByteExpression implements TypedExpression<ByteExpression> {
+  // value is accessible to equality and comparison methods
+  protected final byte value;
+
+  public ByteExpression(byte value) {
+    this.value = value;
+  }
+
+  @Override
+  public DataType dataType() {
+    return DataTypes.ByteType;
+  }
+
+  @Override
+  public boolean eqExpr(InternalRow row, int ordinal) {
+    return row.getByte(ordinal) == value;
+  }
+
+  @Override
+  public boolean gtExpr(InternalRow row, int ordinal) {
+    return row.getByte(ordinal) > value;
+  }
+
+  @Override
+  public boolean ltExpr(InternalRow row, int ordinal) {
+    return row.getByte(ordinal) < value;
+  }
+
+  @Override
+  public boolean geExpr(InternalRow row, int ordinal) {
+    return row.getByte(ordinal) >= value;
+  }
+
+  @Override
+  public boolean leExpr(InternalRow row, int ordinal) {
+    return row.getByte(ordinal) <= value;
+  }
+
+  @Override
+  public boolean containsExpr(ColumnFilter filter) {
+    // TODO: make byte expression support column filter
+    // right now, we always return true
+    return true;
+  }
+
+  @Override
+  public int compareTo(ByteExpression obj) {
+    if (value == obj.value) return 0;
+    return value < obj.value ? -1 : 1;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof ByteExpression)) return false;
+    ByteExpression expr = (ByteExpression) obj;
+    return expr.value == value;
+  }
+
+  @Override
+  public int hashCode() {
+    return value;
+  }
+
+  @Override
+  public TypedExpression copy() {
+    return new ByteExpression(value);
+  }
+
+  @Override
+  public String prettyString() {
+    return "" + value + "b";
+  }
+}

--- a/format/src/main/java/com/github/sadikovi/riff/tree/expression/ShortExpression.java
+++ b/format/src/main/java/com/github/sadikovi/riff/tree/expression/ShortExpression.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2017 sadikovi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.sadikovi.riff.tree.expression;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+
+import com.github.sadikovi.riff.ColumnFilter;
+import com.github.sadikovi.riff.tree.TypedExpression;
+
+/**
+ * [[ShortExpression]] to hold short value that used for comparison for all typed bound references.
+ */
+public class ShortExpression implements TypedExpression<ShortExpression> {
+  // value is accessible to equality and comparison methods
+  protected final short value;
+
+  public ShortExpression(short value) {
+    this.value = value;
+  }
+
+  @Override
+  public DataType dataType() {
+    return DataTypes.ShortType;
+  }
+
+  @Override
+  public boolean eqExpr(InternalRow row, int ordinal) {
+    return row.getShort(ordinal) == value;
+  }
+
+  @Override
+  public boolean gtExpr(InternalRow row, int ordinal) {
+    return row.getShort(ordinal) > value;
+  }
+
+  @Override
+  public boolean ltExpr(InternalRow row, int ordinal) {
+    return row.getShort(ordinal) < value;
+  }
+
+  @Override
+  public boolean geExpr(InternalRow row, int ordinal) {
+    return row.getShort(ordinal) >= value;
+  }
+
+  @Override
+  public boolean leExpr(InternalRow row, int ordinal) {
+    return row.getShort(ordinal) <= value;
+  }
+
+  @Override
+  public boolean containsExpr(ColumnFilter filter) {
+    // TODO: make short expression support column filter
+    // right now, we always return true
+    return true;
+  }
+
+  @Override
+  public int compareTo(ShortExpression obj) {
+    if (value == obj.value) return 0;
+    return value < obj.value ? -1 : 1;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof ShortExpression)) return false;
+    ShortExpression expr = (ShortExpression) obj;
+    return expr.value == value;
+  }
+
+  @Override
+  public int hashCode() {
+    return value;
+  }
+
+  @Override
+  public TypedExpression copy() {
+    return new ShortExpression(value);
+  }
+
+  @Override
+  public String prettyString() {
+    return "" + value + "s";
+  }
+}

--- a/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ConvertersSuite.scala
@@ -37,6 +37,9 @@ class ConvertersSuite extends UnitTestSuite {
     Converters.sqlTypeToConverter(DateType) should be (new IndexedRowIntConverter())
     Converters.sqlTypeToConverter(TimestampType) should be (new IndexedRowLongConverter())
     Converters.sqlTypeToConverter(StringType) should be (new IndexedRowUTF8Converter())
+    Converters.sqlTypeToConverter(BooleanType) should be (new IndexedRowBooleanConverter())
+    Converters.sqlTypeToConverter(ShortType) should be (new IndexedRowShortConverter())
+    Converters.sqlTypeToConverter(ByteType) should be (new IndexedRowByteConverter())
   }
 
   test("converter for unsupported sql type") {
@@ -106,6 +109,32 @@ class ConvertersSuite extends UnitTestSuite {
     cnv.writeDirect(row, 1, fixedBuffer, 4, variableBuffer)
     cnv.writeDirect(row, 2, fixedBuffer, 4, variableBuffer)
     fixedBuffer.array() should be (Array[Byte](1, 0))
+    assert(variableBuffer.array().isEmpty)
+  }
+
+  test("indexed row short converter") {
+    val row = InternalRow(12345.toShort, -67.toShort)
+    val fixedBuffer = new OutputBuffer()
+    val variableBuffer = new OutputBuffer()
+
+    val cnv = new IndexedRowShortConverter()
+    cnv.byteOffset() should be (2)
+    cnv.writeDirect(row, 0, fixedBuffer, 4, variableBuffer)
+    cnv.writeDirect(row, 1, fixedBuffer, 4, variableBuffer)
+    fixedBuffer.array() should be (Array[Byte](48, 57, -1, -67))
+    assert(variableBuffer.array().isEmpty)
+  }
+
+  test("indexed row byte converter") {
+    val row = InternalRow(51.toByte, -67.toByte)
+    val fixedBuffer = new OutputBuffer()
+    val variableBuffer = new OutputBuffer()
+
+    val cnv = new IndexedRowByteConverter()
+    cnv.byteOffset() should be (1)
+    cnv.writeDirect(row, 0, fixedBuffer, 4, variableBuffer)
+    cnv.writeDirect(row, 1, fixedBuffer, 4, variableBuffer)
+    fixedBuffer.array() should be (Array[Byte](51, -67))
     assert(variableBuffer.array().isEmpty)
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/IndexedRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/IndexedRowSuite.scala
@@ -490,4 +490,60 @@ class IndexedRowSuite extends UnitTestSuite {
     ind.getBoolean(1) should be (false)
     assert(ind.get(1, BooleanType) === false)
   }
+
+  test("write/read short type") {
+    val schema = StructType(
+      StructField("col1", ShortType) ::
+      StructField("col2", ShortType) :: Nil)
+    val row = InternalRow(12345.toShort, -673.toShort)
+
+    val td = new TypeDescription(schema, Array("col1"))
+    val writer = new IndexedRowWriter(td)
+    val reader = new IndexedRowReader(td)
+    val stripe = new StripeOutputBuffer(1.toByte)
+    val out = new OutStream(64, null, stripe)
+    writer.writeRow(row, out)
+    out.flush()
+    val in = new InStream(64, null, new StripeInputBuffer(1.toByte, stripe.array()))
+    val ind = reader.readRow(in).asInstanceOf[IndexedRow]
+
+    ind.hasIndexRegion() should be (true)
+    ind.hasDataRegion() should be (true)
+
+    ind.isNullAt(0) should be (false)
+    ind.getShort(0) should be (12345)
+    assert(ind.get(0, ShortType) === 12345)
+
+    ind.isNullAt(1) should be (false)
+    ind.getShort(1) should be (-673)
+    assert(ind.get(1, ShortType) === -673)
+  }
+
+  test("write/read byte type") {
+    val schema = StructType(
+      StructField("col1", ByteType) ::
+      StructField("col2", ByteType) :: Nil)
+    val row = InternalRow(51.toByte, -67.toByte)
+
+    val td = new TypeDescription(schema, Array("col1"))
+    val writer = new IndexedRowWriter(td)
+    val reader = new IndexedRowReader(td)
+    val stripe = new StripeOutputBuffer(1.toByte)
+    val out = new OutStream(64, null, stripe)
+    writer.writeRow(row, out)
+    out.flush()
+    val in = new InStream(64, null, new StripeInputBuffer(1.toByte, stripe.array()))
+    val ind = reader.readRow(in).asInstanceOf[IndexedRow]
+
+    ind.hasIndexRegion() should be (true)
+    ind.hasDataRegion() should be (true)
+
+    ind.isNullAt(0) should be (false)
+    ind.getByte(0) should be (51)
+    assert(ind.get(0, ByteType) === 51)
+
+    ind.isNullAt(1) should be (false)
+    ind.getByte(1) should be (-67)
+    assert(ind.get(1, ByteType) === -67)
+  }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/ProjectionRowSuite.scala
@@ -64,12 +64,14 @@ class ProjectionRowSuite extends UnitTestSuite {
   }
 
   test("get values") {
-    val row = new ProjectionRow(5)
+    val row = new ProjectionRow(7)
     row.update(0, 1)
     row.update(1, 2L)
     row.update(2, UTF8String.fromString("abc"))
     row.update(3, true)
     row.update(4, false)
+    row.update(5, 12345.toShort)
+    row.update(6, 67.toByte)
 
     row.getInt(0) should be (1)
     row.getLong(1) should be (2L)
@@ -82,5 +84,7 @@ class ProjectionRowSuite extends UnitTestSuite {
     row.get(1, TimestampType) should be (2L)
     assert(row.get(3, BooleanType) === true)
     assert(row.get(4, BooleanType) === false)
+    row.get(5, ShortType) should be (12345)
+    row.get(6, ByteType) should be (67)
   }
 }

--- a/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/TypeDescriptionSuite.scala
@@ -56,11 +56,12 @@ class TypeDescriptionSuite extends UnitTestSuite {
     TypeDescription.isSupportedDataType(DateType) should be (true)
     TypeDescription.isSupportedDataType(TimestampType) should be (true)
     TypeDescription.isSupportedDataType(BooleanType) should be (true)
+    TypeDescription.isSupportedDataType(ShortType) should be (true)
+    TypeDescription.isSupportedDataType(ByteType) should be (true)
   }
 
   test("unsupported types") {
-    TypeDescription.isSupportedDataType(ShortType) should be (false)
-    TypeDescription.isSupportedDataType(ByteType) should be (false)
+    TypeDescription.isSupportedDataType(FloatType) should be (false)
     TypeDescription.isSupportedDataType(DoubleType) should be (false)
     TypeDescription.isSupportedDataType(NullType) should be (false)
   }

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/FilterSuite.scala
@@ -84,6 +84,14 @@ class FilterSuite extends UnitTestSuite {
     expr = FilterApi.objToExpression(true)
     expr.isInstanceOf[BooleanExpression] should be (true)
     expr.prettyString should be ("true")
+
+    expr = FilterApi.objToExpression(123.toShort)
+    expr.isInstanceOf[ShortExpression] should be (true)
+    expr.prettyString should be ("123s")
+
+    expr = FilterApi.objToExpression(67.toByte)
+    expr.isInstanceOf[ByteExpression] should be (true)
+    expr.prettyString should be ("67b")
   }
 
   test("FilterApi - objToExpression, exceptions") {

--- a/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/tree/expression/ExpressionSuite.scala
@@ -318,4 +318,136 @@ class ExpressionSuite extends UnitTestSuite {
     expr.leExpr(InternalRow(false), 0) should be (true)
     new BooleanExpression(false).leExpr(InternalRow(true), 0) should be (false)
   }
+
+  test("ShortExpression - misc methods") {
+    val expr = new ShortExpression(512.toShort)
+    expr.dataType should be (ShortType)
+    expr.prettyString should be ("512s")
+    // equals
+    expr.equals(null) should be (false)
+    expr.equals(expr) should be (true)
+    expr.equals(new ShortExpression(457.toShort)) should be (false)
+    expr.equals(new ShortExpression(512.toShort)) should be (true)
+    expr.equals(new ShortExpression(-14.toShort)) should be (false)
+    // hashCode
+    expr.hashCode should be (512.toShort)
+    // compareTo
+    expr.compareTo(expr) should be (0)
+    expr.compareTo(new ShortExpression(-14.toShort)) should be (1)
+    expr.compareTo(new ShortExpression(617.toShort)) should be (-1)
+    // copy
+    expr.copy() should be (expr)
+  }
+
+  test("ShortExpression - check expression") {
+    val expr = new ShortExpression(512.toShort)
+    // equality
+    expr.eqExpr(InternalRow(512.toShort), 0) should be (true)
+    expr.eqExpr(InternalRow(617.toShort), 0) should be (false)
+    expr.eqExpr(InternalRow(-14.toShort), 0) should be (false)
+    expr.eqExpr(InternalRow(0.toShort), 0) should be (false)
+    expr.eqExpr(InternalRow(Short.MaxValue), 0) should be (false)
+    expr.eqExpr(InternalRow(Short.MinValue), 0) should be (false)
+    // greater than
+    expr.gtExpr(InternalRow(512.toShort), 0) should be (false)
+    expr.gtExpr(InternalRow(617.toShort), 0) should be (true)
+    expr.gtExpr(InternalRow(-14.toShort), 0) should be (false)
+    expr.gtExpr(InternalRow(0.toShort), 0) should be (false)
+    expr.gtExpr(InternalRow(Short.MaxValue), 0) should be (true)
+    expr.gtExpr(InternalRow(Short.MinValue), 0) should be (false)
+    // less than
+    expr.ltExpr(InternalRow(512.toShort), 0) should be (false)
+    expr.ltExpr(InternalRow(617.toShort), 0) should be (false)
+    expr.ltExpr(InternalRow(-14.toShort), 0) should be (true)
+    expr.ltExpr(InternalRow(0.toShort), 0) should be (true)
+    expr.ltExpr(InternalRow(Short.MaxValue), 0) should be (false)
+    expr.ltExpr(InternalRow(Short.MinValue), 0) should be (true)
+    // greater than or equal
+    expr.geExpr(InternalRow(512.toShort), 0) should be (true)
+    expr.geExpr(InternalRow(617.toShort), 0) should be (true)
+    expr.geExpr(InternalRow(-14.toShort), 0) should be (false)
+    expr.geExpr(InternalRow(0.toShort), 0) should be (false)
+    expr.geExpr(InternalRow(Short.MaxValue), 0) should be (true)
+    expr.geExpr(InternalRow(Short.MinValue), 0) should be (false)
+    // less than or equal
+    expr.leExpr(InternalRow(512.toShort), 0) should be (true)
+    expr.leExpr(InternalRow(617.toShort), 0) should be (false)
+    expr.leExpr(InternalRow(-14.toShort), 0) should be (true)
+    expr.leExpr(InternalRow(0.toShort), 0) should be (true)
+    expr.leExpr(InternalRow(Short.MaxValue), 0) should be (false)
+    expr.leExpr(InternalRow(Short.MinValue), 0) should be (true)
+  }
+
+  test("ShortExpression - column filter check") {
+    // column filter is always evaluated to true for short types
+    val filter = ColumnFilter.sqlTypeToColumnFilter(ShortType, 16)
+    new ShortExpression(512.toShort).containsExpr(filter) should be (true)
+    new ShortExpression(999.toShort).containsExpr(filter) should be (true)
+  }
+
+  test("ByteExpression - misc methods") {
+    val expr = new ByteExpression(51.toByte)
+    expr.dataType should be (ByteType)
+    expr.prettyString should be ("51b")
+    // equals
+    expr.equals(null) should be (false)
+    expr.equals(expr) should be (true)
+    expr.equals(new ByteExpression(45.toByte)) should be (false)
+    expr.equals(new ByteExpression(51.toByte)) should be (true)
+    expr.equals(new ByteExpression(-3.toByte)) should be (false)
+    // hashCode
+    expr.hashCode should be (51.toByte)
+    // compareTo
+    expr.compareTo(expr) should be (0)
+    expr.compareTo(new ByteExpression(-3.toByte)) should be (1)
+    expr.compareTo(new ByteExpression(61.toByte)) should be (-1)
+    // copy
+    expr.copy() should be (expr)
+  }
+
+  test("ByteExpression - check expression") {
+    val expr = new ByteExpression(51.toByte)
+    // equality
+    expr.eqExpr(InternalRow(51.toByte), 0) should be (true)
+    expr.eqExpr(InternalRow(61.toByte), 0) should be (false)
+    expr.eqExpr(InternalRow(-3.toByte), 0) should be (false)
+    expr.eqExpr(InternalRow(0.toByte), 0) should be (false)
+    expr.eqExpr(InternalRow(Byte.MaxValue), 0) should be (false)
+    expr.eqExpr(InternalRow(Byte.MinValue), 0) should be (false)
+    // greater than
+    expr.gtExpr(InternalRow(51.toByte), 0) should be (false)
+    expr.gtExpr(InternalRow(61.toByte), 0) should be (true)
+    expr.gtExpr(InternalRow(-3.toByte), 0) should be (false)
+    expr.gtExpr(InternalRow(0.toByte), 0) should be (false)
+    expr.gtExpr(InternalRow(Byte.MaxValue), 0) should be (true)
+    expr.gtExpr(InternalRow(Byte.MinValue), 0) should be (false)
+    // less than
+    expr.ltExpr(InternalRow(51.toByte), 0) should be (false)
+    expr.ltExpr(InternalRow(61.toByte), 0) should be (false)
+    expr.ltExpr(InternalRow(-3.toByte), 0) should be (true)
+    expr.ltExpr(InternalRow(0.toByte), 0) should be (true)
+    expr.ltExpr(InternalRow(Byte.MaxValue), 0) should be (false)
+    expr.ltExpr(InternalRow(Byte.MinValue), 0) should be (true)
+    // greater than or equal
+    expr.geExpr(InternalRow(51.toByte), 0) should be (true)
+    expr.geExpr(InternalRow(61.toByte), 0) should be (true)
+    expr.geExpr(InternalRow(-3.toByte), 0) should be (false)
+    expr.geExpr(InternalRow(0.toByte), 0) should be (false)
+    expr.geExpr(InternalRow(Byte.MaxValue), 0) should be (true)
+    expr.geExpr(InternalRow(Byte.MinValue), 0) should be (false)
+    // less than or equal
+    expr.leExpr(InternalRow(51.toByte), 0) should be (true)
+    expr.leExpr(InternalRow(61.toByte), 0) should be (false)
+    expr.leExpr(InternalRow(-3.toByte), 0) should be (true)
+    expr.leExpr(InternalRow(0.toByte), 0) should be (true)
+    expr.leExpr(InternalRow(Byte.MaxValue), 0) should be (false)
+    expr.leExpr(InternalRow(Byte.MinValue), 0) should be (true)
+  }
+
+  test("ByteExpression - column filter check") {
+    // column filter is always evaluated to true for byte types
+    val filter = ColumnFilter.sqlTypeToColumnFilter(ByteType, 16)
+    new ByteExpression(43.toByte).containsExpr(filter) should be (true)
+    new ByteExpression(-56.toByte).containsExpr(filter) should be (true)
+  }
 }

--- a/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
@@ -271,6 +271,20 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
     checkDataType(BooleanType, seq, _.filter(col("col") === true))
   }
 
+  test("write/read dataframe, ShortType") {
+    val seq = Row(12345.toShort) :: Row(-671.toShort) :: Row(null) :: Nil
+    checkDataType(ShortType, seq)
+    checkDataType(ShortType, seq, _.filter("col is null"))
+    checkDataType(ShortType, seq, _.filter(col("col") === -671.toShort))
+  }
+
+  test("write/read dataframe, ByteType") {
+    val seq = Row(51.toByte) :: Row(-67.toByte) :: Row(null) :: Nil
+    checkDataType(ByteType, seq)
+    checkDataType(ByteType, seq, _.filter("col is null"))
+    checkDataType(ByteType, seq, _.filter(col("col") === -67.toByte))
+  }
+
   //////////////////////////////////////////////////////////////
   // == Write/read checks for compression codecs
   //////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR adds support for `ByteType` and `ShortType` and statistics classes for these types. Column filters are not implemented, and will be added in follow-up PRs.