### PR TITLE
Metadata count

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ running `spark.conf.set("option", "value")`.
 | `spark.sql.riff.column.filter.enabled` | When enabled, write column filters in addition to min/max/null statistics (`true`, `false`) | `true`
 | `spark.sql.riff.buffer.size` | Buffer size in bytes for out/in stream | `256 * 1024`
 | `spark.sql.riff.filterPushdown` | When enabled, propagate filter to riff format, otherwise filter data in Spark only | `true`
+| `spark.sql.riff.metadata.count.enabled` | When enabled, use metadata information for count queries, otherwise read table data  | `true`
 
 ## DataFrame options
 These options that you can specify when writing DataFrame by calling `df.write.option("key", "value").save(...)`.

--- a/format/src/main/java/com/github/sadikovi/riff/FileHeader.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileHeader.java
@@ -52,7 +52,7 @@ public class FileHeader {
   private final TypeDescription td;
   // file statistics
   private final Statistics[] fileStats;
-  // number of records in file, do not expecte more than Integer.MAX_VALUE
+  // number of records in file, do not expect more than Integer.MAX_VALUE
   private final int numRecords;
 
   /**

--- a/format/src/main/java/com/github/sadikovi/riff/FileHeader.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileHeader.java
@@ -52,21 +52,28 @@ public class FileHeader {
   private final TypeDescription td;
   // file statistics
   private final Statistics[] fileStats;
+  // number of records in file, do not expecte more than Integer.MAX_VALUE
+  private final int numRecords;
 
   /**
    * Initialize file header with state, type description and file statisitcs.
    * @param state file state
    * @param td file type description
    * @param fileStats file statistics
+   * @param numRecords number of records in file
    */
-  public FileHeader(byte[] state, TypeDescription td, Statistics[] fileStats) {
+  public FileHeader(byte[] state, TypeDescription td, Statistics[] fileStats, int numRecords) {
     if (state.length != STATE_LENGTH) {
       throw new IllegalArgumentException("Invalid state length, " +
         state.length + " != " + STATE_LENGTH);
     }
+    if (numRecords < 0) {
+      throw new IllegalArgumentException("Negative number of records: " + numRecords);
+    }
     this.state = state;
     this.td = td;
     this.fileStats = fileStats;
+    this.numRecords = numRecords;
   }
 
   /**
@@ -74,9 +81,10 @@ public class FileHeader {
    * State can be modified using `setState` method.
    * @param td type description
    * @param fileStats file statistics
+   * @param numRecords number of records in file
    */
-  public FileHeader(TypeDescription td, Statistics[] fileStats) {
-    this(new byte[STATE_LENGTH], td, fileStats);
+  public FileHeader(TypeDescription td, Statistics[] fileStats, int numRecords) {
+    this(new byte[STATE_LENGTH], td, fileStats, numRecords);
   }
 
   /**
@@ -105,6 +113,14 @@ public class FileHeader {
   }
 
   /**
+   * Get number of records recorded in file header.
+   * @return number of records in file
+   */
+  public int getNumRecords() {
+    return numRecords;
+  }
+
+  /**
    * Get state flag for posiiton.
    * @param pos position of the flag
    * @return state value
@@ -124,6 +140,7 @@ public class FileHeader {
     // record file header
     buffer.write(state);
     td.writeTo(buffer);
+    buffer.writeInt(numRecords);
     buffer.writeInt(fileStats.length);
     int i = 0;
     while (i < fileStats.length) {
@@ -164,6 +181,7 @@ public class FileHeader {
     // wraps byte buffer, stream updates position of buffer
     ByteBufferStream byteStream = new ByteBufferStream(buffer);
     TypeDescription td = TypeDescription.readFrom(byteStream);
+    int numRecords = buffer.getInt();
     // read file statistics
     Statistics[] fileStats = new Statistics[buffer.getInt()];
     int i = 0;
@@ -172,6 +190,6 @@ public class FileHeader {
       LOG.debug("Read file statistics {}", fileStats[i]);
       ++i;
     }
-    return new FileHeader(state, td, fileStats);
+    return new FileHeader(state, td, fileStats, numRecords);
   }
 }

--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -253,6 +253,8 @@ public class FileWriter {
         StripeInformation stripeInfo =
           new StripeInformation(stripe, currentOffset, stripeStats, stripeFilters);
         currentOffset += stripeInfo.length();
+        // written numRowsInStripe records
+        totalRecords += numRowsInStripe;
         stripe.flush(temporaryStream);
         LOG.debug("Finished writing stripe {}, records={}", stripeInfo, numRowsInStripe);
         stripes.add(stripeInfo);
@@ -265,7 +267,6 @@ public class FileWriter {
       updateColumnFilters(stripeFilters, td, row);
       recordWriter.writeRow(row, stripeStream);
       stripeCurrentRecords--;
-      totalRecords++;
     } catch (IOException ioe) {
       if (temporaryStream != null) {
         temporaryStream.close();
@@ -290,6 +291,8 @@ public class FileWriter {
       stripe.flush(temporaryStream);
       LOG.debug("Finished writing stripe {}, records={}", stripeInfo,
         numRowsInStripe - stripeCurrentRecords);
+      // update total records with delta
+      totalRecords += numRowsInStripe - stripeCurrentRecords;
       stripes.add(stripeInfo);
       stripeStream.close();
       stripe = null;

--- a/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileWriter.java
@@ -113,6 +113,8 @@ public class FileWriter {
   private OutStream stripeStream;
   // number of records in current stripe
   private int stripeCurrentRecords;
+  // total number of records in file
+  private int totalRecords;
   // statistics per stripe
   private Statistics[] stripeStats;
   // column filters per stripe
@@ -212,6 +214,7 @@ public class FileWriter {
     LOG.debug("Prepare file writer {}", this);
     stripeId = 0;
     currentOffset = 0L;
+    totalRecords = 0;
     stripes = new ArrayList<StripeInformation>();
     recordWriter = new IndexedRowWriter(td);
     LOG.debug("Initialized record writer {}", recordWriter);
@@ -262,6 +265,7 @@ public class FileWriter {
       updateColumnFilters(stripeFilters, td, row);
       recordWriter.writeRow(row, stripeStream);
       stripeCurrentRecords--;
+      totalRecords++;
     } catch (IOException ioe) {
       if (temporaryStream != null) {
         temporaryStream.close();
@@ -310,7 +314,7 @@ public class FileWriter {
       // write complete file
       LOG.debug("Write file header");
       outputStream = fs.create(filePath, false, hdfsBufferSize);
-      FileHeader fileHeader = new FileHeader(td, fileStats);
+      FileHeader fileHeader = new FileHeader(td, fileStats, totalRecords);
       fileHeader.setState(0, Riff.encodeCompressionCodec(codec));
       fileHeader.writeTo(outputStream);
       // write stripe information

--- a/format/src/main/java/com/github/sadikovi/riff/row/ProjectionRow.java
+++ b/format/src/main/java/com/github/sadikovi/riff/row/ProjectionRow.java
@@ -44,13 +44,16 @@ import org.apache.spark.unsafe.types.UTF8String;
 public class ProjectionRow extends GenericInternalRow {
   // internal array to keep all values
   private final Object[] values;
+  private final int numFields;
 
   /**
    * Create instance of this row with expected number of fields.
    * @param size number of fields
    */
   public ProjectionRow(int size) {
-    this.values = new Object[size];
+    if (size < 0) throw new IllegalArgumentException("Negative number of fields: " + size);
+    this.values = (size == 0) ? null : new Object[size];
+    this.numFields = size;
   }
 
   /**
@@ -60,6 +63,7 @@ public class ProjectionRow extends GenericInternalRow {
    */
   protected ProjectionRow(Object[] values) {
     this.values = values;
+    this.numFields = values.length;
   }
 
   /**
@@ -72,7 +76,7 @@ public class ProjectionRow extends GenericInternalRow {
 
   @Override
   public int numFields() {
-    return values.length;
+    return numFields;
   }
 
   @Override
@@ -82,8 +86,8 @@ public class ProjectionRow extends GenericInternalRow {
 
   @Override
   public ProjectionRow copy() {
-    Object[] copy = new Object[values.length];
-    System.arraycopy(values, 0, copy, 0, values.length);
+    Object[] copy = new Object[numFields];
+    System.arraycopy(values, 0, copy, 0, numFields);
     return new ProjectionRow(copy);
   }
 
@@ -104,8 +108,8 @@ public class ProjectionRow extends GenericInternalRow {
 
   @Override
   public boolean anyNull() {
-    int len = values.length, i = 0;
-    while (i < len) {
+    int i = 0;
+    while (i < numFields) {
       if (isNullAt(i)) return true;
       ++i;
     }
@@ -199,7 +203,7 @@ public class ProjectionRow extends GenericInternalRow {
 
   @Override
   public String toString() {
-    if (values.length == 0) {
+    if (numFields == 0) {
       return "[empty row]";
     } else {
       return Arrays.toString(values);

--- a/format/src/test/scala/com/github/sadikovi/riff/FileHeaderSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/FileHeaderSuite.scala
@@ -36,19 +36,32 @@ class FileHeaderSuite extends UnitTestSuite {
 
   test("state length check") {
     var err = intercept[IllegalArgumentException] {
-      new FileHeader(new Array[Byte](1), null, null)
+      new FileHeader(new Array[Byte](1), null, null, 0)
     }
     err.getMessage should be ("Invalid state length, 1 != 8")
 
     err = intercept[IllegalArgumentException] {
-      new FileHeader(new Array[Byte](10), null, null)
+      new FileHeader(new Array[Byte](10), null, null, 0)
     }
     err.getMessage should be ("Invalid state length, 10 != 8")
 
     // valid state length
-    val header = new FileHeader(new Array[Byte](8), null, null)
+    val header = new FileHeader(new Array[Byte](8), null, null, 0)
     header.getTypeDescription should be (null)
     header.getFileStatistics should be (null)
+    header.getNumRecords should be (0)
+  }
+
+  test("check wrong number of records") {
+    var err = intercept[IllegalArgumentException] {
+      new FileHeader(new Array[Byte](8), null, null, -1)
+    }
+    err.getMessage should be ("Negative number of records: -1")
+
+    err = intercept[IllegalArgumentException] {
+      new FileHeader(new Array[Byte](8), null, null, Int.MinValue)
+    }
+    err.getMessage should be (s"Negative number of records: ${Int.MinValue}")
   }
 
   test("check wrong magic number") {
@@ -73,7 +86,7 @@ class FileHeaderSuite extends UnitTestSuite {
       val list = Array[Statistics](
         stats(1, 10, false)
       )
-      val header1 = new FileHeader(state, td, list)
+      val header1 = new FileHeader(state, td, list, 156378)
       val out = fs.create(dir / "header")
       header1.writeTo(out)
       out.close()
@@ -84,6 +97,7 @@ class FileHeaderSuite extends UnitTestSuite {
 
       header2.getTypeDescription should be (header1.getTypeDescription)
       header2.getFileStatistics should be (header1.getFileStatistics)
+      header2.getNumRecords should be (156378)
       for (i <- 0 until state.length) {
         header2.state(i) should be (header1.state(i))
       }

--- a/format/src/test/scala/com/github/sadikovi/riff/row/ProjectionRowSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/row/ProjectionRowSuite.scala
@@ -50,6 +50,19 @@ class ProjectionRowSuite extends UnitTestSuite {
     row.toString should be ("[empty row]")
   }
 
+  test("initialize with negative size") {
+    val err = intercept[IllegalArgumentException] {
+      new ProjectionRow(-1)
+    }
+    err.getMessage should be ("Negative number of fields: -1")
+  }
+
+  test("initialize with null array") {
+    intercept[NullPointerException] {
+      new ProjectionRow(null)
+    }
+  }
+
   test("update values") {
     val row = new ProjectionRow(3)
     row.numFields should be (3)
@@ -61,6 +74,19 @@ class ProjectionRowSuite extends UnitTestSuite {
     row.update(2, 3)
     row.anyNull should be (false)
     row.toString should be ("[1, 2, 3]")
+  }
+
+  test("copy projection row") {
+    val row = new ProjectionRow(3)
+    row.update(0, 1)
+    row.update(1, 2L)
+    row.update(2, true)
+
+    val copy = row.copy()
+    copy.numFields should be (row.numFields)
+    copy.anyNull should be (row.anyNull)
+    copy.values should be (row.values)
+    copy.toString should be (row.toString)
   }
 
   test("get int value") {

--- a/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
@@ -229,6 +229,44 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
     }
   }
 
+  test("check metadata count") {
+    withSQLConf(RiffFileFormat.SQL_RIFF_METADATA_COUNT -> "true") {
+      withTempDir { dir =>
+        spark.range(1237).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (1237)
+      }
+
+      withTempDir { dir =>
+        spark.range(0).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (0)
+      }
+
+      withTempDir { dir =>
+        spark.range(99999).write.riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (99999)
+      }
+    }
+  }
+
+  test("check metadata count + filter") {
+    withSQLConf(RiffFileFormat.SQL_RIFF_METADATA_COUNT -> "true") {
+      withTempDir { dir =>
+        spark.range(1237).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").filter("id < 100").count should be (100)
+      }
+
+      withTempDir { dir =>
+        spark.range(0).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").filter("id = -1").count should be (0)
+      }
+
+      withTempDir { dir =>
+        spark.range(99999).write.riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").filter("id != 0").count should be (99998)
+      }
+    }
+  }
+
   //////////////////////////////////////////////////////////////
   // == Write/read tests for different datatypes
   //////////////////////////////////////////////////////////////

--- a/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/RiffSQLSuite.scala
@@ -230,6 +230,7 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
   }
 
   test("check metadata count") {
+    // default number of records in stripe
     withSQLConf(RiffFileFormat.SQL_RIFF_METADATA_COUNT -> "true") {
       withTempDir { dir =>
         spark.range(1237).write.option("index", "id").riff(dir.toString / "table")
@@ -239,6 +240,25 @@ class RiffSQLSuite extends UnitTestSuite with SparkLocal {
       withTempDir { dir =>
         spark.range(0).write.option("index", "id").riff(dir.toString / "table")
         spark.read.riff(dir.toString / "table").count should be (0)
+      }
+
+      withTempDir { dir =>
+        spark.range(99999).write.riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (99999)
+      }
+    }
+    // small number of records in stripe
+    withSQLConf(
+        RiffFileFormat.SQL_RIFF_METADATA_COUNT -> "true",
+        RiffFileFormat.SQL_RIFF_STRIPE_ROWS -> "12") {
+      withTempDir { dir =>
+        spark.range(1200).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (1200)
+      }
+
+      withTempDir { dir =>
+        spark.range(11).write.option("index", "id").riff(dir.toString / "table")
+        spark.read.riff(dir.toString / "table").count should be (11)
       }
 
       withTempDir { dir =>


### PR DESCRIPTION
This PR updates format to store number of records in metadata. This allows us to implement efficient count query using metadata information as oppose to reading all records in table.

This behaviour can be disabled using `spark.sql.riff.metadata.count.enabled`, which is enabled by default.

Closes #28.