### PR TITLE
Remove IsNotNull tree node for null-safe filters

### DIFF
--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/DefaultSource.scala
@@ -186,8 +186,7 @@ class DefaultSource
       SQL_RIFF_FILTER_PUSHDOWN_DEFAULT).toBoolean
 
     val predicate = if (filterPushdownEnabled) {
-      val reducedFilter = filters.reduceOption(And)
-      val tree = Filters.createRiffFilter(reducedFilter)
+      val tree = Filters.createRiffFilter(filters)
       if (tree != null) {
         log.info(s"Applying filter tree $tree")
       }

--- a/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
+++ b/sql/src/main/scala/com/github/sadikovi/spark/riff/Filters.scala
@@ -100,10 +100,30 @@ private[riff] object Filters {
     }
   }
 
+  /** Find references for tree node, park 2.0 does not have references for filters */
+  private def references(value: Filter): Seq[String] = value match {
+    case EqualTo(attribute, _) => Seq(attribute)
+    case EqualNullSafe(attribute, _) => Seq(attribute)
+    case GreaterThan(attribute, _) => Seq(attribute)
+    case GreaterThanOrEqual(attribute, _) => Seq(attribute)
+    case LessThan(attribute, _) => Seq(attribute)
+    case LessThanOrEqual(attribute, _) => Seq(attribute)
+    case In(attribute, _) => Seq(attribute)
+    case IsNull(attribute) => Seq(attribute)
+    case IsNotNull(attribute) => Seq(attribute)
+    case StringStartsWith(attribute, _) => Seq(attribute)
+    case StringEndsWith(attribute, _) => Seq(attribute)
+    case StringContains(attribute, _) => Seq(attribute)
+    case And(left: Filter, right: Filter) => references(left) ++ references(right)
+    case Or(left: Filter, right: Filter) => references(left) ++ references(right)
+    case Not(child: Filter) => references(child)
+    case _ => Seq.empty
+  }
+
   /** Whether or not two filters have the same references */
   def sameReferences(left: Filter, right: Filter): Boolean = {
     left.references.length == right.references.length &&
-      left.references.toSeq == right.references.toSeq
+      references(left) == references(right)
   }
 
   /**

--- a/sql/src/test/com/github/sadikovi/spark/riff/SparkFiltersSuite.scala
+++ b/sql/src/test/com/github/sadikovi/spark/riff/SparkFiltersSuite.scala
@@ -29,31 +29,33 @@ import com.github.sadikovi.riff.tree.FilterApi._
 import com.github.sadikovi.testutil.UnitTestSuite
 
 class SparkFiltersSuite extends UnitTestSuite {
-  test("sameReferences") {
-    Filters.sameReferences(IsNull("col1"), IsNull("col1")) should be (true)
-    Filters.sameReferences(IsNull("col1"), EqualTo("col1", 1)) should be (true)
-    Filters.sameReferences(
+  test("check references") {
+    assert(Filters.references(IsNull("col1")) == Filters.references(IsNull("col1")))
+    assert(Filters.references(IsNull("col1")) == Filters.references(EqualTo("col1", 1)))
+    assert(Filters.references(
       Or(
         EqualTo("col1", 1),
         GreaterThan("col2", 2)
-      ),
+      )
+    ) == Filters.references(
       And(
         EqualTo("col1", 3),
         LessThan("col2", 0)
       )
-    ) should be (true)
+    ))
 
     // check that order of tree nodes is the same
-    Filters.sameReferences(
+    assert(Filters.references(
       And(
         EqualTo("col1", 1),
         EqualTo("col2", 1)
-      ),
+      )
+    ) != Filters.references(
       And(
         EqualTo("col2", 1),
         EqualTo("col1", 1)
       )
-    ) should be (false)
+    ))
   }
 
   test("isLeaf") {


### PR DESCRIPTION
This PR fixes TODO item on handling `IsNotNull` for filters that are null safe. Most of the leaf nodes in Riff are null safe, they will discard any null values when encountered. We remove `IsNotNull` when conjunction filter contains another subtree which is leaf and has the same references as `IsNotNull` node.

Closes #23.