### PR TITLE
Add file properties to specify user metadata

### DIFF
--- a/format/src/main/java/com/github/sadikovi/riff/FileReader.java
+++ b/format/src/main/java/com/github/sadikovi/riff/FileReader.java
@@ -179,6 +179,7 @@ public class FileReader {
    * File footer for this reader.
    * Only available after calling prepareRead() or `readFileFooter` methods.
    * @return file footer
+   * @throws IllegalStateException if not set
    */
   public FileFooter getFileFooter() {
     if (fileFooter == null) {
@@ -211,6 +212,40 @@ public class FileReader {
         in.close();
       }
     }
+  }
+
+  /**
+   * Get file property.
+   * Header must be initialized before calling this method.
+   * @param key file property key
+   * @return value as String or null, if no such key exists
+   */
+  public String getFileProperty(String key) {
+    return getFileHeader().getProperty(key);
+  }
+
+  /**
+   * Get file path for this reader.
+   * @return file path
+   */
+  public Path filePath() {
+    return getFileStatus().getPath();
+  }
+
+  /**
+   * Get file status for this reader.
+   * @return file status
+   */
+  public FileStatus getFileStatus() {
+    return fileStatus;
+  }
+
+  /**
+   * Return buffer size selected for this reader to use in instream.
+   * @return buffer size
+   */
+  public int bufferSize() {
+    return bufferSize;
   }
 
   /**
@@ -264,30 +299,6 @@ public class FileReader {
     }
     Arrays.sort(stripes);
     return stripes;
-  }
-
-  /**
-   * Get file path for this reader.
-   * @return file path
-   */
-  public Path filePath() {
-    return getFileStatus().getPath();
-  }
-
-  /**
-   * Get file status for this reader.
-   * @return file status
-   */
-  public FileStatus getFileStatus() {
-    return fileStatus;
-  }
-
-  /**
-   * Return buffer size selected for this reader to use in instream.
-   * @return buffer size
-   */
-  public int bufferSize() {
-    return bufferSize;
   }
 
   @Override

--- a/format/src/main/java/com/github/sadikovi/riff/Riff.java
+++ b/format/src/main/java/com/github/sadikovi/riff/Riff.java
@@ -47,6 +47,9 @@ import com.github.sadikovi.riff.io.CompressionCodecFactory;
  * TypeDescription td = new TypeDescription(structType, indexFields);
  * FileWriter writer = Riff.writer(conf, path, td);
  *
+ * // set custom file property
+ * writer.setFileProperty("key", "value");
+ *
  * writer.prepareWrite();
  * while (rows.hasNext()) {
  *   writer.write(rows.next());
@@ -54,9 +57,14 @@ import com.github.sadikovi.riff.io.CompressionCodecFactory;
  * writer.finishWrite();
  *
  * // reading file
- * TreeNode filter = eqt("indexField", "abc");
+ * TreeNode filter = eqt("fieldName", "value");
  * FileReader reader = Riff.reader(conf, new org.apache.hadoop.fs.Path("file.gz"));
+ *
  * RowBuffer rowbuf = reader.prepareRead(filter);
+ *
+ * // get custom file property, must be called after prepareRead() or readFileInfo()
+ * String value = reader.getFileProperty("key");
+ *
  * while (rowbuf.hasNext()) {
  *   process(rowbuf.next()); // user-specific processing of an InternalRow
  * }

--- a/format/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/FileWriterSuite.scala
@@ -144,6 +144,36 @@ class FileWriterSuite extends UnitTestSuite {
     }
   }
 
+  test("fail to set property when write is in progress") {
+    withTempDir { dir =>
+      val conf = new Configuration(false)
+      val path = dir / "file"
+      val codec = new ZlibCodec()
+      val td = new TypeDescription(StructType(StructField("col", StringType) :: Nil))
+      val writer = new FileWriter(fs, conf, path, td, codec)
+      writer.prepareWrite()
+      intercept[IllegalStateException] {
+        writer.setFileProperty("key", "value")
+      }
+    }
+  }
+
+  test("fail to set property if key/value is null") {
+    withTempDir { dir =>
+      val conf = new Configuration(false)
+      val path = dir / "file"
+      val codec = new ZlibCodec()
+      val td = new TypeDescription(StructType(StructField("col", StringType) :: Nil))
+      val writer = new FileWriter(fs, conf, path, td, codec)
+      intercept[IllegalArgumentException] {
+        writer.setFileProperty("key", null)
+      }
+      intercept[IllegalArgumentException] {
+        writer.setFileProperty(null, "value")
+      }
+    }
+  }
+
   test("write batch of rows in one stripe") {
     withTempDir { dir =>
       val conf = new Configuration(false)

--- a/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
+++ b/format/src/test/scala/com/github/sadikovi/riff/RiffSuite.scala
@@ -377,6 +377,31 @@ class RiffSuite extends UnitTestSuite {
     }
   }
 
+  test("write/read, with gzip, check file properties") {
+    withTempDir { dir =>
+      val conf = new Configuration(false)
+      val td = new TypeDescription(schema, Array("col2"))
+      val writer = Riff.writer(conf, dir / "file", td)
+
+      writer.setFileProperty("key1", "value1")
+      writer.setFileProperty("key2", "value2")
+      writer.setFileProperty("", "value3")
+      writer.setFileProperty("key3", "")
+
+      writer.prepareWrite()
+      writer.finishWrite()
+
+      val reader = Riff.reader(dir / "file")
+      reader.readFileInfo(true)
+
+      reader.getFileProperty("key1") should be ("value1")
+      reader.getFileProperty("key2") should be ("value2")
+      reader.getFileProperty("") should be ("value3")
+      reader.getFileProperty("key3") should be ("")
+      reader.getFileProperty("key999") should be (null)
+    }
+  }
+
   // == direct scan ==
 
   test("write/read with snappy, direct scan") {


### PR DESCRIPTION
This PR adds ability to specify user key-value pairs as part of header metadata. Currently this functionality is added to reader/writer, not in sql module. Key/value must be non-null string value.

Properties can be set and accessed with following code:
```java
FileWriter writer = Riff.writer(conf, path, td);
// set custom file property, must be called before `prepareWrite()`
writer.setFileProperty("key", "value");
writer.prepareWrite();

FileReader reader = Riff.reader(conf, path);
reader.prepareRead(filter); // or reader.readFileInfo(true)
// get custom file property, must be called after prepareRead() or readFileInfo()
String value = reader.getFileProperty("key");
```